### PR TITLE
Remove snyk-container-scan from CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -316,56 +316,17 @@ jobs:
             --type=coverage-metrics
 
 
-  snyk-container-scan:
-    runs-on: ubuntu-latest
-    needs: [build-image]
-    env:
-      IMAGE_NAME:        ${{ needs.build-image.outputs.tagged_image_name }}
-      KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
-      SARIF_FILENAME:    snyk.container.scan.json
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@v2
-        with:
-          egress-policy: audit
-
-      - name: Download docker image
-        uses: cyber-dojo/download-artifact@main
-        with:
-          image_digest: ${{ needs.build-image.outputs.digest }}
-
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Setup Snyk
-        uses: snyk/actions/setup@master
-
-      - name: Run Snyk container scan
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run:
-          make snyk_container_scan
-
-      - name: Setup Kosli CLI
-        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
-        uses: kosli-dev/setup-cli-action@v2
-        with:
-          version: ${{ vars.KOSLI_CLI_VERSION }}
-
-      - name: Attest evidence to Kosli
-        if: ${{ github.ref == 'refs/heads/main' && (success() || failure()) }}
-        run:
-          kosli attest snyk 
-            --attachments=.snyk          
-            --name=runner.snyk-container-scan 
-            --scan-results="${SARIF_FILENAME}"
-
 
   sdlc-control-gate:
     if: ${{ github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
-    needs: [build-image, pull-request, rubocop-lint, unit-tests, integration-tests, snyk-container-scan, snyk-code-scan]
+    needs:
+      - build-image
+      - pull-request 
+      - rubocop-lint
+      - unit-tests
+      - integration-tests
+      - snyk-code-scan
     env:
       KOSLI_FINGERPRINT: ${{ needs.build-image.outputs.digest }}
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -334,7 +334,7 @@ jobs:
         with:
           image_digest: ${{ needs.build-image.outputs.digest }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,8 +229,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run unit tests
-        run: |
-          docker image ls
+        run:
           make test_server coverage_server 
 
       - name: Setup Kosli CLI

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,7 +229,8 @@ jobs:
           fetch-depth: 1
 
       - name: Run unit tests
-        run:
+        run: |
+          docker image ls
           make test_server coverage_server 
 
       - name: Setup Kosli CLI

--- a/.kosli.yml
+++ b/.kosli.yml
@@ -24,7 +24,5 @@ trail:
         - name: integration-test-coverage-metrics
           type: custom:coverage-metrics
 
-        - name: snyk-container-scan
-          type: snyk
         - name: snyk-code-scan
           type: snyk

--- a/bin/snyk_container_scan.sh
+++ b/bin/snyk_container_scan.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -Eeu
 
-set -x
-
 export ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${ROOT_DIR}/bin/lib.sh"
 source "${ROOT_DIR}/bin/echo_env_vars.sh"
@@ -13,6 +11,8 @@ readonly IMAGE_NAME="${CYBER_DOJO_RUNNER_IMAGE}:${CYBER_DOJO_RUNNER_TAG}"
 readonly SARIF_FILENAME=${SARIF_FILENAME:-snyk.container.scan.json}
 
 exit_non_zero_unless_installed snyk
+
+docker image ls 
 
 snyk container test "${IMAGE_NAME}" -d \
   --policy-path="${ROOT_DIR}/.snyk" \

--- a/bin/snyk_container_scan.sh
+++ b/bin/snyk_container_scan.sh
@@ -12,8 +12,6 @@ readonly SARIF_FILENAME=${SARIF_FILENAME:-snyk.container.scan.json}
 
 exit_non_zero_unless_installed snyk
 
-docker image ls 
-
 snyk container test "${IMAGE_NAME}" -d \
   --policy-path="${ROOT_DIR}/.snyk" \
   --sarif \

--- a/bin/snyk_container_scan.sh
+++ b/bin/snyk_container_scan.sh
@@ -17,7 +17,7 @@ snyk container test "${IMAGE_NAME}" -d \
   --sarif \
   --sarif-file-output="${ROOT_DIR}/${SARIF_FILENAME}" | /tmp/snyk.log
 
-EXIT_CODE=$?
+EXIT_CODE=${PIPESTATUS[0]}
 
 if [ grep Forbidden /tmp/snyk.log ]; then
   >&2 echo FAILED: snyk container test ...

--- a/bin/snyk_container_scan.sh
+++ b/bin/snyk_container_scan.sh
@@ -17,8 +17,14 @@ docker image ls
 snyk container test "${IMAGE_NAME}" -d \
   --policy-path="${ROOT_DIR}/.snyk" \
   --sarif \
-  --sarif-file-output="${ROOT_DIR}/${SARIF_FILENAME}"
+  --sarif-file-output="${ROOT_DIR}/${SARIF_FILENAME}" | /tmp/snyk.log
 
 EXIT_CODE=$?
+
+if [ grep Forbidden /tmp/snyk.log ]; then
+  >&2 echo FAILED: snyk container test ...
+  EXIT_CODE=42
+fi
+
 echo "EXIT_CODE=:${EXIT_CODE}:"
 exit ${EXIT_CODE}


### PR DESCRIPTION
Currently, the snyk-container-scan produces no terminal output, does not create the requested sarif file, and exits with a status code of zero. How rubbish is that! So I am taking the opportunity to move to a new snyk process design inspired by Tore's work. The snyk-scans will now happen only in a dedicated process with its own cron workflow. And I will work towards implementing a policy of making a failed snyk attestation only become non-compliant if it is not fixed in 7 days.