### PR TITLE
Increase tmpfs max sizes to 250MB

### DIFF
--- a/source/server/runner.rb
+++ b/source/server/runner.rb
@@ -224,8 +224,8 @@ class Runner
   #     - set ownership.
   # - - - - - - - - - - - - - - - - - - - - - -
 
-  TMP_FS_SANDBOX_DIR = "--tmpfs #{Sandbox::DIR}:exec,size=50M,uid=#{UID},gid=#{GID}".freeze
-  TMP_FS_TMP_DIR     = '--tmpfs /tmp:exec,size=50M,mode=1777'.freeze # Set /tmp sticky-bit
+  TMP_FS_SANDBOX_DIR = "--tmpfs #{Sandbox::DIR}:exec,size=250M,uid=#{UID},gid=#{GID}".freeze
+  TMP_FS_TMP_DIR     = '--tmpfs /tmp:exec,size=250M,mode=1777'.freeze # Set /tmp sticky-bit
 
   def utf8_clean(result)
     result[:stdout] = Utf8.clean(result[:stdout])


### PR DESCRIPTION
A cyber-dojo supporter and user is trying to add a new test-framework, reqnroll (which is a replacement for C# SpecFlow) and it the tests pass locally, but he is getting file-size exceeded (+ core dump) errors when the tests run in the github CI workflow. This PR increases the max size of the tmpfs volume mounts from 50MB to 250MB in the hope this will make a difference.