### PR TITLE
Increase ulimit for max file size

### DIFF
--- a/source/server/runner.rb
+++ b/source/server/runner.rb
@@ -169,16 +169,17 @@ class Runner
   end
 
   def ulimits(image_name)
-    # [1] the nproc --limit is per user across all containers. See
+    # [1] Some start-points have large dll files, eg C# dotnet
+    # [2] The nproc --limit is per user across all containers. See
     # https://docs.docker.com/engine/reference/commandline/run/#set-ulimits-in-container---ulimit
     # There is no cpu-ulimit. See
     # https://github.com/cyber-dojo-retired/runner-stateless/issues/2
     options = [
       ulimit('core', 0), # no core file
-      ulimit('fsize', 128 * MB), # file size
+      ulimit('fsize', 256 * MB), # file size [1]
       ulimit('locks', 1024), # number of file locks
       ulimit('nofile', 1024), # number of files
-      ulimit('nproc', 1024), # number of processes [1]
+      ulimit('nproc', 1024), # number of processes [2]
       ulimit('stack', 16 * MB),           # stack size
       '--kernel-memory=768m',             # limited
       '--memory=768m',                    # max 768MB ram (same swap)
@@ -220,8 +221,9 @@ class Runner
   #   o) relatime = Update inode access times relative to modify/change time.
   #   So...
   #     - set exec to make binaries and scripts executable.
-  #     - limit size of tmp-fs.
   #     - set ownership.
+  #     - limit size of tmp-fs. Some start-points require large files,
+  #       eg, C#'s "dotnet restore"
   # - - - - - - - - - - - - - - - - - - - - - -
 
   TMP_FS_SANDBOX_DIR = "--tmpfs #{Sandbox::DIR}:exec,size=250M,uid=#{UID},gid=#{GID}".freeze

--- a/test/client/container_properties_test.rb
+++ b/test/client/container_properties_test.rb
@@ -129,7 +129,7 @@ class ContainerPropertiesTest < TestBase
     refute timed_out?, pretty_result(:timed_out)
 
     expected_max_data_size = clang? ? 0 : 4 * GB / BLOCK_SIZE
-    expected_max_file_size  = 128 * MB / BLOCK_SIZE
+    expected_max_file_size  = 256 * MB / BLOCK_SIZE
     expected_max_stack_size = 16 * MB / BLOCK_SIZE
 
     assert_ulimit 0,                       :core_size


### PR DESCRIPTION
A cyber-dojo supporter and user is trying to add a C# reqnroll start-point using dotnet. It passes all tests locally, but fails in the CI workflow with a max-file-size exceeded error. So I am increasing the ulimit for max file size to see if that helps.