### PR TITLE
Make all runner-ci Flow tags explicit, add env

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,15 @@ jobs:
             --description="Test runner"
             --template-file=.kosli.yml
 
+      - name: Tag Kosli Flow
+        if: github.ref == 'refs/heads/main'
+        run:
+          kosli tag flow "${KOSLI_FLOW}"
+            --set env=${KOSLI_AWS_BETA}
+            --set kind=build
+            --set ci=github
+            --set repo_url=${{ github.server_url }}/${{ github.repository }}
+
       - name: Begin Kosli Trail
         if: github.ref == 'refs/heads/main'
         run:


### PR DESCRIPTION
  runner creates its Flow inline (not via kosli-begin-trail) and had no tag step,
  so its tags (ci, repo_url, kind=build) were only set implicitly by kosli create
  flow / persisted state, and env was missing entirely. Add a kosli tag flow step
  that sets all of them explicitly: env=aws-beta (for the per-environment
  trail-compliance policies), plus kind=build, ci=github and repo_url so the
  workflow no longer depends on auto-tagging or pre-existing state.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>