### PR TITLE
Document containerd CRI label vuln CVE-2026-53488 as not exploitable

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -214,3 +214,10 @@ ignore:
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
+  # CVE-2026-53488 | containerd CRI labels | Score 8.7 | Not exploitable: dockerd uses moby integration, not the containerd CRI plugin; runner only runs trusted images
+  SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524:
+    - '*':
+        reason: Waiting for fix
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-06-24T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524.txt
@@ -1,0 +1,20 @@
+SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524 | github.com/containerd/containerd/v2/pkg/labels | CVSS 8.7 | High | CVE-2026-53488
+What: The containerd CRI plugin propagates LABEL values from an image's
+config to container labels without validation. A downstream consumer of those
+labels (the restart-monitor's binary:// logger) then runs them, so a crafted
+image LABEL becomes arbitrary command execution on the host as root, triggered
+by pulling/running the malicious image. Exploitation requires the CRI plugin
+(the Kubernetes/crictl runtime path) and an attacker-supplied image.
+Fix available: containerd 2.0.10, 2.1.9, 2.2.5, 2.3.2 (and 1.7.33 on the 1.7 line)
+For cyber-dojo: containerd ships inside the dind image as part of Docker
+Engine. The runner reaches Docker only through dockerd via the mounted
+/var/run/docker.sock, and dockerd uses its own moby/containerd client
+integration -- NOT the containerd CRI plugin, which is only exercised by
+Kubernetes/crictl. The CRI plugin is therefore never enabled or invoked. The
+runner also runs only fixed, trusted language images (cyberdojofoundation/*,
+ghcr.io/cyber-dojo-languages/*); user code runs inside a container with
+--net=none, --user=41966:51966 and --security-opt=no-new-privileges, and
+cannot supply its own image or its LABEL values.
+Verdict: Not exploitable. The vulnerable code path is the containerd CRI
+plugin, which Docker Engine does not use; and the runner never pulls
+attacker-controlled images whose LABELs could reach it.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -18,6 +18,7 @@ CVE / ID               Package                 Score  Exploitable?  Reason
 ------------------------------------------------------------------------------
 CVE-2026-39821         golang.org/x/net/idna    9.3   No   runner resolves only trusted endpoints; no user-controlled IDNA input
 CVE-2026-33186         gRPC-Go                  9.1   No   --net=none; no gRPC exposure
+CVE-2026-53488         containerd CRI labels    8.7   No   dockerd uses moby integration, not the CRI plugin; only trusted images run
 CVE-2026-29181         OTel baggage+family      8.7   No   --net=none; can't send baggage headers
 CVE-2026-33814         golang.org/x/net/http2   8.7   No   --net=none; can't send SETTINGS frames
 CVE-2026-46597         x/crypto/ssh             8.7   No   --net=none; no SSH server exposed


### PR DESCRIPTION
  A new snyk scan flagged SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524
  (CVE-2026-53488, CVSS 8.7) in github.com/containerd/containerd/v2/pkg/labels:
  unvalidated image LABEL values propagate to container labels and reach the
  restart-monitor binary:// logger, giving host-root command execution from an
  image pull.

  This is not exploitable in the runner. The vulnerable path is the containerd
  CRI plugin (the Kubernetes/crictl runtime), but the runner reaches Docker only
  through dockerd over the mounted socket, and dockerd uses its own
  moby/containerd integration rather than the CRI plugin. The runner also only
  runs fixed, trusted language images, so no attacker-controlled LABELs can reach
  it; user code additionally runs with --net=none, non-root, and no-new-privileges.

  Record the assessment in docs/vulns/, add the readme summary row, and add a
  .snyk ignore entry so the build stays compliant once the grace period elapses.