### PR TITLE
Document containerd v2/client vuln CVE-2026-53488 as not exploitable

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -221,3 +221,10 @@ ignore:
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
+  # CVE-2026-53488 | containerd v2/client | Score 8.7 | Not exploitable: same CVE as 17391524 attributed to a second containerd package; runner only runs trusted images so no attacker LABELs reach any path
+  SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516:
+    - '*':
+        reason: Waiting for fix
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-06-24T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516.txt
@@ -1,0 +1,28 @@
+SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516 | github.com/containerd/containerd/v2/client | CVSS 8.7 | High | CVE-2026-53488
+What: This is the same advisory as
+SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524 (CVE-2026-53488),
+which Snyk attributes to a second import path in the containerd module. The
+containerd CRI plugin propagates LABEL values from an image's config to
+container labels without validation; a downstream consumer (the
+restart-monitor's binary:// logger) then runs them, so a crafted image LABEL
+becomes arbitrary command execution on the host as root when the malicious
+image is pulled/run. The vulnerable mechanism lives in the CRI plugin's
+label-handling path, not in the generic client API; both packages are flagged
+because the fix ships at the module level (identical fixed versions).
+Fix available: containerd 2.0.10, 2.1.9, 2.2.5, 2.3.2 (and 1.7.33 on the 1.7 line)
+For cyber-dojo: containerd ships inside the dind image as part of Docker
+Engine. Unlike pkg/labels, the v2/client package IS reachable in principle,
+because dockerd's moby/containerd integration uses the containerd client API.
+However, the exploit requires two things that do not hold here. First, the
+vulnerable label-propagation-to-logger behaviour is the CRI plugin path
+(Kubernetes/crictl), which Docker Engine does not enable or invoke. Second,
+and independently of the package argument, exploitation needs an
+attacker-controlled image whose LABELs reach the host. The runner only ever
+runs fixed, trusted language images (cyberdojofoundation/*,
+ghcr.io/cyber-dojo-languages/*); user code runs inside a container with
+--net=none, --user=41966:51966 and --security-opt=no-new-privileges, and
+cannot supply its own image or its LABEL values.
+Verdict: Not exploitable. Even taking the conservative view that v2/client is
+linked, the runner never pulls or runs attacker-controlled images, so no
+crafted LABEL can reach any code path; and the vulnerable behaviour itself is
+the CRI plugin, which Docker Engine does not use.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -19,6 +19,7 @@ CVE / ID               Package                 Score  Exploitable?  Reason
 CVE-2026-39821         golang.org/x/net/idna    9.3   No   runner resolves only trusted endpoints; no user-controlled IDNA input
 CVE-2026-33186         gRPC-Go                  9.1   No   --net=none; no gRPC exposure
 CVE-2026-53488         containerd CRI labels    8.7   No   dockerd uses moby integration, not the CRI plugin; only trusted images run
+CVE-2026-53488         containerd v2/client     8.7   No   same CVE as above, 2nd package (Snyk 17391516); CRI plugin path unused; only trusted images run
 CVE-2026-29181         OTel baggage+family      8.7   No   --net=none; can't send baggage headers
 CVE-2026-33814         golang.org/x/net/http2   8.7   No   --net=none; can't send SETTINGS frames
 CVE-2026-46597         x/crypto/ssh             8.7   No   --net=none; no SSH server exposed


### PR DESCRIPTION
    Snyk reports CVE-2026-53488 against two packages in the containerd module,
    as two separate Snyk IDs. PR #250 documented and ignored only the pkg/labels
    one (SNYK-GOLANG-...PKGLABELS-17391524), so the v2/client instance
    (SNYK-GOLANG-...V2CLIENT-17391516, CVSS 8.7) was left uncovered. With no
    .snyk entry and its 2-day high-severity grace already elapsed, it shows as
    fail_high in the snyk-container-scan decision and fails the SDLC gate.

    Unlike pkg/labels, v2/client is reachable in principle since dockerd's
    moby integration links the containerd client API, so the "CRI plugin not
    used" argument alone is not enough. The assessment instead rests on the
    independent defence that the runner only runs fixed, trusted images and
    user code cannot supply its own image or LABEL values (--net=none,
    non-root, no-new-privileges) -- so no crafted LABEL can reach any path.

    Add the .snyk ignore entry, a docs/vulns/ assessment file, and the readme
    summary row so the build stays compliant once re-evaluated. The real fix
    is bumping containerd to 2.0.10 / 2.1.9 / 2.2.5 / 2.3.2+, which clears both
    Snyk IDs together.