### PR TITLE
Document CVE-2026-50195 and correct misleading snyk ignore reasons

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -7,224 +7,231 @@ ignore:
   # CVE-2026-24051 | OTel SDK resource | Score 7.3 | Not exploitable: macOS-only (ioreg)
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15182758:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-33186 | gRPC-Go | Score 9.1 | Not exploitable: --net=none; no gRPC exposure
   SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-15928420:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELINTERNALGLOBAL-15928418:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-15928416:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPMETRICOTLPMETRICHTTP-15954197:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15954212:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # no CVE | aws-sdk-go-v2 CloudWatch Logs EventStream | Score 8.2 | Not exploitable: requires MITM of TLS CloudWatch endpoint; DoS only
   SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICECLOUDWATCHLOGS-16316406:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-08T10:53:10.201Z
 
   # CVE-2026-33814 | golang.org/x/net/http2 | Score 8.7 | Not exploitable: Go agent connects to trusted internal endpoints only; attacker cannot inject SETTINGS_MAX_FRAME_SIZE=0
   SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-08T10:53:10.201Z
 
   # CVE-2026-46597 | x/crypto/ssh | Score 8.7 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39835 | x/crypto/ssh | Score 8.7 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-46598 | x/crypto/ssh/agent | Score 8.7 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796334:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39831 | x/crypto/ssh | Score 8.6 | Not exploitable: --net=none; client-side; no outbound SSH
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795344:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39827 | x/crypto/ssh | Score 7.1 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39829 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795338:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39834 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795340:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39830 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796305:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39828 | x/crypto/ssh | Score 5.3 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796309:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-46595 | x/crypto/ssh | Score 5.3 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796316:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39832 | x/crypto/ssh/agent | Score 5.3 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796343:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39833 | x/crypto/ssh/agent | Score 5.3 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796347:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-41178 | OTel propagation | Score 6.9 | Not exploitable: affected binaries are dockerd (Unix socket only) and docker-compose/docker-buildx (CLI tools, no inbound HTTP)
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-17054905:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-41178 | OTel baggage | Score 6.9 | Not exploitable: affected binaries are dockerd (Unix socket only) and docker-compose/docker-buildx (CLI tools, no inbound HTTP)
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-17054906:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-39821 | golang.org/x/net/idna | Score 9.3 | Not exploitable: runner resolves only trusted endpoints; no user-controlled input reaches IDNA path
   SNYK-GOLANG-GOLANGORGXNETIDNA-17116876:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-42506 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873672:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-27136 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873674:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-42502 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873676:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-25681 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873774:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-25680 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML parsed
   SNYK-GOLANG-GOLANGORGXNETHTML-16873779:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-53488 | containerd CRI labels | Score 8.7 | Not exploitable: dockerd uses moby integration, not the containerd CRI plugin; runner only runs trusted images
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
   # CVE-2026-53488 | containerd v2/client | Score 8.7 | Not exploitable: same CVE as 17391524 attributed to a second containerd package; runner only runs trusted images so no attacker LABELs reach any path
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516:
     - '*':
-        reason: Waiting for fix
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-06-24T00:00:00.000Z
+
+  # CVE-2026-50195 | containerd CRI checkpoint import | Score 5.6 (GHSA rates Critical) | Not exploitable: CRI/Kubernetes checkpoint-import path; dockerd uses the moby integration not CRI; runner is not Kubernetes and runs only trusted images
+  SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17393921:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17393921.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17393921.txt
@@ -1,0 +1,34 @@
+SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17393921 | github.com/containerd/containerd/v2/pkg/labels | CVSS 5.6 (GHSA rates Critical) | CVE-2026-50195 | GHSA-cvxm-645q-p574
+What: A separate containerd advisory from CVE-2026-53488, flagged against the
+same pkg/labels import path but a distinct flaw: "CRI checkpoint import allows
+local image tag poisoning". containerd's CRI checkpoint-import process fails to
+validate the image references inside a checkpoint image's configuration, so an
+attacker can inject a malicious image into the local image cache under an
+arbitrary local tag. Subsequent pods that use the poisoned tag with an
+IfNotPresent or Never pull policy then unknowingly execute attacker-controlled
+code under the victim pod's identity.
+Note on score: Snyk reports CVSS 5.6 (Medium); the upstream GitHub advisory
+GHSA-cvxm-645q-p574 rates it Critical. We treat the higher rating as the one
+to defend against.
+Fix available: containerd 2.1.9, 2.2.5, 2.3.2 (vulnerable: >=2.1.0 <2.1.9,
+>=2.2.0 <2.2.5, >=2.3.0 <2.3.1). Same fixed versions as CVE-2026-53488, which
+is why both advisories clear on the same module bump.
+For cyber-dojo: containerd ships inside the dind image as part of Docker
+Engine. Exploitation requires three things, none of which hold here. First,
+the vulnerable code is the CRI checkpoint-import path, which is the
+Kubernetes/CRI runtime interface; the runner reaches Docker only through
+dockerd via the mounted /var/run/docker.sock, and dockerd uses its own
+moby/containerd client integration, NOT the containerd CRI plugin. The CRI
+plugin is never enabled or invoked. Second, the attack needs a threat actor
+with permission to create pods on the target -- the runner is not Kubernetes
+and has no pods, no kubelet and no crictl. Third, it needs an attacker-supplied
+crafted checkpoint image; the runner only ever runs fixed, trusted language
+images (cyberdojofoundation/*, ghcr.io/cyber-dojo-languages/*), and user code
+runs inside a container with --net=none, --user=41966:51966 and
+--security-opt=no-new-privileges, and cannot supply its own image, checkpoint
+or tags.
+Verdict: Not exploitable. The vulnerable path is the containerd CRI checkpoint
+import, which Docker Engine does not use; the runner is not Kubernetes so there
+is no pod-create surface; and the runner never imports attacker-controlled
+checkpoint images. The real fix is bumping containerd to 2.1.9 / 2.2.5 /
+2.3.2+, which clears this advisory alongside CVE-2026-53488.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -33,6 +33,7 @@ CVE-2026-41178         OTel baggage/propagation 6.9   No   Docker toolchain only
 CVE-2026-39829         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-39834         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-39830         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
+CVE-2026-50195         containerd CRI checkpoint 5.6  No   CRI checkpoint import (Kubernetes); dockerd uses moby integration; not K8s; only trusted images (GHSA: Critical)
 CVE-2026-39828         x/crypto/ssh             5.3   No   --net=none; no SSH server exposed
 CVE-2026-46595         x/crypto/ssh             5.3   No   --net=none; no SSH server exposed
 CVE-2026-39832         x/crypto/ssh/agent       5.3   No   --net=none; no SSH agent exposed


### PR DESCRIPTION
  Snyk flagged SNYK-GOLANG-...PKGLABELS-17393921 against the runner. Despite
  sharing the containerd pkg/labels import path with the already-documented
  CVE-2026-53488, it is a different advisory (GHSA-cvxm-645q-p574): "CRI
  checkpoint import allows local image tag poisoning". Snyk scores it CVSS 5.6
  but the upstream advisory rates it Critical, so it must be assessed, not left
  to age out. It is not exploitable here: the vulnerable path is the CRI
  checkpoint-import process (Kubernetes/CRI only); dockerd reaches containerd
  through the moby integration, not the CRI plugin; the runner is not Kubernetes
  (no pod-create surface); and it only ever imports fixed, trusted images.

  Add the .snyk ignore entry, a docs/vulns/ assessment file, and the readme
  summary row. The real fix is bumping containerd to 2.1.9 / 2.2.5 / 2.3.2+,
  which clears this alongside CVE-2026-53488.

  Also reword every .snyk reason from "Waiting for fix" to "Not exploitable in
  runner context; see docs/vulns/readme.txt". The old text was misleading: each
  entry's documented justification is that the vuln is structurally unreachable
  given the runner's posture, not that we are awaiting an upstream patch (for
  several, a fixed version already exists). The reason text does not affect
  compliance evaluation. The explicit expiries are kept deliberately, so each
  not-exploitable verdict is re-confirmed periodically rather than suppressed
  forever.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>