### PR TITLE
Ignore CVE-2026-48702 (sigstore/rekor) as not exploitable in runner

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -242,3 +242,10 @@ ignore:
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
+  # CVE-2026-48702 | sigstore/rekor pkg/types | Score 8.7 | Not exploitable: server-side DoS against a Rekor server's unauthenticated APK-upload endpoints; runner runs no Rekor server and --net=none blocks user code from any endpoint
+  SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-06-30T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875.txt
@@ -1,0 +1,25 @@
+SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875 | github.com/sigstore/rekor/pkg/types | CVSS 8.7 | High | CVE-2026-48702
+What: "Allocation of Resources Without Limits or Throttling" (CWE-770). A Rekor
+transparency-log server can be crashed by sending a specially crafted
+gzip-compressed APK file with a very high compression ratio to its
+unauthenticated upload endpoints. Inflating the bomb consumes excessive memory,
+so an unauthenticated remote attacker can exhaust the server's memory and take
+the process down. The vulnerable code is the Alpine/APK entry type in Rekor's
+pkg/types, which only runs on the server side when ingesting a submitted log
+entry.
+Fix available: rekor 1.5.2 (vulnerable: >=0.3.0 <1.5.2).
+For cyber-dojo: rekor/pkg/types is part of the sigstore transparency-log
+toolchain; it is linked transitively through the Docker image-signing and
+attestation toolchain (cosign / docker buildx) bundled in the dind image, not
+through any code cyber-dojo writes. The vulnerability is purely server-side: it
+requires operating a Rekor transparency-log server that exposes the
+unauthenticated APK-upload endpoints and accepts attacker-supplied log entries.
+The runner does not run a Rekor server, exposes no such endpoint, and ingests
+no externally submitted log entries. User code runs inside a sandbox container
+with --net=none, --user=41966:51966 and --security-opt=no-new-privileges, so it
+cannot reach any network endpoint at all, let alone submit a crafted APK to a
+Rekor upload handler. Whatever links pkg/types does so as a client of the public
+sigstore infrastructure, never as a server.
+Verdict: Not exploitable. The DoS targets a Rekor server's unauthenticated
+upload endpoints; the runner runs no Rekor server and the affected ingest path
+is never invoked. The real fix is bumping rekor to 1.5.2+.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -25,6 +25,7 @@ CVE-2026-33814         golang.org/x/net/http2   8.7   No   --net=none; can't sen
 CVE-2026-46597         x/crypto/ssh             8.7   No   --net=none; no SSH server exposed
 CVE-2026-39835         x/crypto/ssh             8.7   No   --net=none; no SSH server exposed
 CVE-2026-46598         x/crypto/ssh/agent       8.7   No   --net=none; no SSH agent exposed
+CVE-2026-48702         sigstore/rekor pkg/types 8.7   No   server-side DoS; runner runs no Rekor server; --net=none blocks user code
 CVE-2026-39831         x/crypto/ssh             8.6   No   --net=none; client-side; no outbound SSH
 CloudWatch-16316406    aws-sdk-go-v2 CloudWatch 8.2   No   --net=none; DoS only; requires MITM of TLS
 CVE-2026-24051         OTel SDK resource        7.3   No   macOS-only (ioreg)


### PR DESCRIPTION
  Snyk flags SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875
  (CVE-2026-48702, CVSS 8.7) in github.com/sigstore/rekor/pkg/types. The
  vulnerability is a gzip-APK decompression-bomb DoS against a Rekor
  transparency-log server's unauthenticated upload endpoints. The runner
  runs no Rekor server: pkg/types is only linked transitively via the
  sigstore/Docker signing toolchain as a client of public infrastructure,
  and user code runs with --net=none so it cannot reach any endpoint. The
  vulnerable server-side ingest path is never invoked.

  Add the .snyk ignore entry, a docs/vulns assessment file, and a summary
  table row, consistent with the other not-exploitable advisories.