### PR TITLE
Ignore 18 low-severity Alpine curl vulns (libcurl kept for git)

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -249,3 +249,129 @@ ignore:
         expires: 2026-07-16T10:53:10.182Z
         created: 2026-06-30T00:00:00.000Z
 
+  # CVE-2026-11586 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17716543:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-11352 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17716663:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-12064 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717190:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-9079 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717313:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8286 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717410:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8932 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717433:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-9545 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717489:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-11564 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717495:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8458 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717584:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-9546 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717618:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-11856 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717651:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8925 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717674:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-9547 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717707:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8924 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717716:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-9080 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717717:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8926 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717718:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-10536 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717719:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-8927 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
+  SNYK-ALPINE324-CURL-17717720:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-07-16T10:53:10.182Z
+        created: 2026-07-03T00:00:00.000Z
+

--- a/docs/vulns/SNYK-ALPINE324-CURL.txt
+++ b/docs/vulns/SNYK-ALPINE324-CURL.txt
@@ -1,0 +1,57 @@
+curl / libcurl (18 CVEs) | Alpine 3.24 apk package "curl" < 8.21.0-r0 | Low each
+CVE-2026-11586  Snyk SNYK-ALPINE324-CURL-17716543
+CVE-2026-11352  Snyk SNYK-ALPINE324-CURL-17716663
+CVE-2026-12064  Snyk SNYK-ALPINE324-CURL-17717190
+CVE-2026-9079   Snyk SNYK-ALPINE324-CURL-17717313
+CVE-2026-8286   Snyk SNYK-ALPINE324-CURL-17717410
+CVE-2026-8932   Snyk SNYK-ALPINE324-CURL-17717433
+CVE-2026-9545   Snyk SNYK-ALPINE324-CURL-17717489
+CVE-2026-11564  Snyk SNYK-ALPINE324-CURL-17717495
+CVE-2026-8458   Snyk SNYK-ALPINE324-CURL-17717584
+CVE-2026-9546   Snyk SNYK-ALPINE324-CURL-17717618
+CVE-2026-11856  Snyk SNYK-ALPINE324-CURL-17717651
+CVE-2026-8925   Snyk SNYK-ALPINE324-CURL-17717674
+CVE-2026-9547   Snyk SNYK-ALPINE324-CURL-17717707
+CVE-2026-8924   Snyk SNYK-ALPINE324-CURL-17717716
+CVE-2026-9080   Snyk SNYK-ALPINE324-CURL-17717717
+CVE-2026-8926   Snyk SNYK-ALPINE324-CURL-17717718
+CVE-2026-10536  Snyk SNYK-ALPINE324-CURL-17717719
+CVE-2026-8927   Snyk SNYK-ALPINE324-CURL-17717720
+
+All eighteen are in the Alpine 3.24 "curl" apk package and are fixed in
+curl 8.21.0-r0 (vulnerable: < 8.21.0-r0). All are Low severity. None has been
+analysed by NVD yet, so no CVSS vector or CWE is published; Snyk lists them at
+its default "low" assessment.
+
+What: a batch of curl/libcurl flaws disclosed together in the curl 8.21.0
+release. Because NVD has not scored or described them yet, the precise
+mechanisms are undisclosed, but they are all in curl -- a network client for
+HTTP(S), FTP and related protocols -- so any exploit path requires curl to
+perform a network transfer, typically against an attacker-controlled or
+attacker-influenced endpoint or response.
+
+For cyber-dojo: the runner base image (cyberdojo/docker-base, alpine 3.24)
+deliberately does NOT ship the curl command-line binary -- it was removed, and
+the healthcheck scripts use BusyBox wget instead (see
+source/server/config/healthcheck.sh: "Default Alpine image has wget (but not
+curl)"). The "curl" apk package is nonetheless still installed because git
+depends on libcurl for its HTTP/HTTPS remote transport, so Snyk sees the
+package and flags it.
+
+Nothing in the runner drives that libcurl transport with untrusted input:
+
+  - The runner server is Ruby; it makes no curl/libcurl calls of its own.
+  - The only use of git in the image is local plumbing -- "git rev-parse HEAD"
+    (bin/echo_env_vars.sh) -- which never opens a network connection, so
+    libcurl's HTTP code path is never exercised. The runner does not clone or
+    fetch from attacker-controlled https:// remotes.
+  - User code runs inside a sandbox container with --net=none,
+    --user=41966:51966 and --security-opt=no-new-privileges, so it has no
+    network access at all and cannot make curl/libcurl reach any endpoint,
+    even if it invoked curl (which is absent) or a libcurl-linked binary.
+
+Verdict: Not exploitable. The curl CLI is not present; libcurl exists only as a
+transitive dependency of git, whose network transport the runner never invokes
+on untrusted input; and user code has no network access under --net=none. All
+eighteen are Low severity with NVD analysis still pending. The real fix arrives
+when the docker-base image bumps its Alpine "curl" package to >= 8.21.0-r0.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01
+Generated: 2026-06-01 (curl/libcurl low-severity batch added 2026-07-03)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -45,6 +45,32 @@ CVE-2026-27136         golang.org/x/net/html    5.3   No   only docker-buildx li
 CVE-2026-42502         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25681         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25680         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML parsed
+curl 18 CVEs (below)   Alpine curl < 8.21.0-r0  low   No   curl CLI removed; libcurl only via git (no net transport used); --net=none; see SNYK-ALPINE324-CURL.txt
+
+== curl / libcurl low-severity batch (Alpine 3.24 apk "curl" < 8.21.0-r0) ==
+
+The curl CLI is removed from the base image; the "curl" apk package remains only
+because git links libcurl. All Low, NVD analysis pending (no CVSS yet).
+Detail and exploitability assessment: docs/vulns/SNYK-ALPINE324-CURL.txt
+
+CVE-2026-11586  SNYK-ALPINE324-CURL-17716543
+CVE-2026-11352  SNYK-ALPINE324-CURL-17716663
+CVE-2026-12064  SNYK-ALPINE324-CURL-17717190
+CVE-2026-9079   SNYK-ALPINE324-CURL-17717313
+CVE-2026-8286   SNYK-ALPINE324-CURL-17717410
+CVE-2026-8932   SNYK-ALPINE324-CURL-17717433
+CVE-2026-9545   SNYK-ALPINE324-CURL-17717489
+CVE-2026-11564  SNYK-ALPINE324-CURL-17717495
+CVE-2026-8458   SNYK-ALPINE324-CURL-17717584
+CVE-2026-9546   SNYK-ALPINE324-CURL-17717618
+CVE-2026-11856  SNYK-ALPINE324-CURL-17717651
+CVE-2026-8925   SNYK-ALPINE324-CURL-17717674
+CVE-2026-9547   SNYK-ALPINE324-CURL-17717707
+CVE-2026-8924   SNYK-ALPINE324-CURL-17717716
+CVE-2026-9080   SNYK-ALPINE324-CURL-17717717
+CVE-2026-8926   SNYK-ALPINE324-CURL-17717718
+CVE-2026-10536  SNYK-ALPINE324-CURL-17717719
+CVE-2026-8927   SNYK-ALPINE324-CURL-17717720
 
 == Key caveat ==
 


### PR DESCRIPTION
  The latest base-image update surfaced 18 new low-severity SNYK-ALPINE324-CURL
  vulns (curl < 8.21.0-r0). The curl CLI was removed from the base image, but the
  curl apk package stays because git links libcurl for its HTTP transport.

  None are exploitable in the runner: the CLI is absent, git's libcurl transport
  is never driven on untrusted input (only local `git rev-parse`), and user code
  runs --net=none. All are Low with NVD analysis still pending; the real fix is
  docker-base bumping curl to >= 8.21.0-r0.

  Add .snyk ignore entries and docs/vulns files documenting the assessment, per
  the usual convention.