### PR TITLE
 Ignore cilium/ebpf/btf DoS vuln and extend all .snyk expiries to 202…

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -8,370 +8,377 @@ ignore:
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15182758:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-33186 | gRPC-Go | Score 9.1 | Not exploitable: --net=none; no gRPC exposure
   SNYK-GOLANG-GOOGLEGOLANGORGGRPC-15691172:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-15928420:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELINTERNALGLOBAL-15928418:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-15928416:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPTRACEOTLPTRACEHTTP-15954196:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELEXPORTERSOTLPOTLPMETRICOTLPMETRICHTTP-15954197:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # CVE-2026-29181 | OTel baggage+family | Score 8.7 | Not exploitable: --net=none; can't send baggage headers
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELSDKRESOURCE-15954212:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-04-09T10:53:10.201Z
 
   # no CVE | aws-sdk-go-v2 CloudWatch Logs EventStream | Score 8.2 | Not exploitable: requires MITM of TLS CloudWatch endpoint; DoS only
   SNYK-GOLANG-GITHUBCOMAWSAWSSDKGOV2SERVICECLOUDWATCHLOGS-16316406:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-08T10:53:10.201Z
 
   # CVE-2026-33814 | golang.org/x/net/http2 | Score 8.7 | Not exploitable: Go agent connects to trusted internal endpoints only; attacker cannot inject SETTINGS_MAX_FRAME_SIZE=0
   SNYK-GOLANG-GOLANGORGXNETHTTP2-16535157:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-08T10:53:10.201Z
 
   # CVE-2026-46597 | x/crypto/ssh | Score 8.7 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796326:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39835 | x/crypto/ssh | Score 8.7 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796332:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-46598 | x/crypto/ssh/agent | Score 8.7 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796334:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39831 | x/crypto/ssh | Score 8.6 | Not exploitable: --net=none; client-side; no outbound SSH
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795344:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39827 | x/crypto/ssh | Score 7.1 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795342:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39829 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795338:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39834 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16795340:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39830 | x/crypto/ssh | Score 6.9 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796305:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39828 | x/crypto/ssh | Score 5.3 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796309:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-46595 | x/crypto/ssh | Score 5.3 | Not exploitable: --net=none; no SSH server exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSH-16796316:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39832 | x/crypto/ssh/agent | Score 5.3 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796343:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-39833 | x/crypto/ssh/agent | Score 5.3 | Not exploitable: --net=none; no SSH agent exposed
   SNYK-GOLANG-GOLANGORGXCRYPTOSSHAGENT-16796347:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-05-23T10:53:10.201Z
 
   # CVE-2026-41178 | OTel propagation | Score 6.9 | Not exploitable: affected binaries are dockerd (Unix socket only) and docker-compose/docker-buildx (CLI tools, no inbound HTTP)
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELPROPAGATION-17054905:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-41178 | OTel baggage | Score 6.9 | Not exploitable: affected binaries are dockerd (Unix socket only) and docker-compose/docker-buildx (CLI tools, no inbound HTTP)
   SNYK-GOLANG-GOOPENTELEMETRYIOOTELBAGGAGE-17054906:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-39821 | golang.org/x/net/idna | Score 9.3 | Not exploitable: runner resolves only trusted endpoints; no user-controlled input reaches IDNA path
   SNYK-GOLANG-GOLANGORGXNETIDNA-17116876:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-01T00:00:00.000Z
 
   # CVE-2026-42506 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873672:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-27136 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873674:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-42502 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873676:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-25681 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML rendered
   SNYK-GOLANG-GOLANGORGXNETHTML-16873774:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-25680 | x/net/html | Score 5.3 | Not exploitable: only docker-buildx links html pkg; build-time CLI plugin; no untrusted HTML parsed
   SNYK-GOLANG-GOLANGORGXNETHTML-16873779:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-05T00:00:00.000Z
 
   # CVE-2026-53488 | containerd CRI labels | Score 8.7 | Not exploitable: dockerd uses moby integration, not the containerd CRI plugin; runner only runs trusted images
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17391524:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
   # CVE-2026-53488 | containerd v2/client | Score 8.7 | Not exploitable: same CVE as 17391524 attributed to a second containerd package; runner only runs trusted images so no attacker LABELs reach any path
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17391516:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
   # CVE-2026-50195 | containerd CRI checkpoint import | Score 5.6 (GHSA rates Critical) | Not exploitable: CRI/Kubernetes checkpoint-import path; dockerd uses the moby integration not CRI; runner is not Kubernetes and runs only trusted images
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2PKGLABELS-17393921:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
   # CVE-2026-50195 | containerd v2/client | Score 5.6 (GHSA rates Critical) | Not exploitable: same CVE as 17393921 attributed to a second containerd package; CRI checkpoint-import path unused; runner is not Kubernetes and runs only trusted images
   SNYK-GOLANG-GITHUBCOMCONTAINERDCONTAINERDV2CLIENT-17393922:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-24T00:00:00.000Z
 
   # CVE-2026-48702 | sigstore/rekor pkg/types | Score 8.7 | Not exploitable: server-side DoS against a Rekor server's unauthenticated APK-upload endpoints; runner runs no Rekor server and --net=none blocks user code from any endpoint
   SNYK-GOLANG-GITHUBCOMSIGSTOREREKORPKGTYPES-17660875:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-06-30T00:00:00.000Z
 
   # CVE-2026-11586 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17716543:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-11352 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17716663:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-12064 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717190:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-9079 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717313:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8286 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717410:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8932 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717433:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-9545 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717489:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-11564 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717495:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8458 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717584:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-9546 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717618:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-11856 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717651:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8925 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717674:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-9547 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717707:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8924 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717716:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-9080 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717717:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8926 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717718:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-10536 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717719:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
 
   # CVE-2026-8927 | Alpine curl < 8.21.0-r0 | Low (NVD pending) | Not exploitable: curl CLI removed; libcurl only via git; --net=none; see docs/vulns/SNYK-ALPINE324-CURL.txt
   SNYK-ALPINE324-CURL-17717720:
     - '*':
         reason: Not exploitable in runner context; see docs/vulns/readme.txt
-        expires: 2026-07-16T10:53:10.182Z
+        expires: 2026-08-03T10:53:10.182Z
         created: 2026-07-03T00:00:00.000Z
+
+  # CVE-2026-10722 | cilium/ebpf/btf | Score 4.8 | Not exploitable: sandboxed user code lacks CAP_BPF to load eBPF; only trusted toolchain BTF specs parsed; DoS only
+  SNYK-GOLANG-GITHUBCOMCILIUMEBPFBTF-17810931:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-03T10:53:10.182Z
+        created: 2026-07-04T00:00:00.000Z
 

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMCILIUMEBPFBTF-17810931.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMCILIUMEBPFBTF-17810931.txt
@@ -1,0 +1,25 @@
+SNYK-GOLANG-GITHUBCOMCILIUMEBPFBTF-17810931 | github.com/cilium/ebpf/btf | CVSS 4.8 | Medium | CVE-2026-10722
+What: "Integer Overflow or Wraparound" (CWE-190). An integer overflow in the
+loadRawSpec function when parsing a BTF (BPF Type Format) collection
+specification. An attacker who can supply a specially crafted collection spec
+to an application that calls LoadCollectionSpec or LoadCollectionSpecFromReader
+can trigger excessive memory allocation or parsing failures. Impact is
+availability only (a DoS / crash); there is no confidentiality or integrity
+effect. Attack vector is Local, complexity Low, and a proof-of-concept exists,
+but EPSS is 0.18% (8th percentile).
+Fix available: cilium/ebpf 0.22.0 (vulnerable: < 0.22.0).
+For cyber-dojo: github.com/cilium/ebpf is a pure-Go library for reading and
+loading eBPF programs into the Linux kernel. It is linked transitively through
+the Docker/containerd/runc toolchain bundled in the dind image (used for cgroup
+device controllers, seccomp and network eBPF programs), not through any code
+cyber-dojo writes. Exploiting this requires feeding an attacker-controlled BTF
+collection spec (a compiled eBPF object) into the vulnerable parse path. User
+code cannot do this: loading eBPF programs requires CAP_BPF / CAP_SYS_ADMIN,
+which the sandbox denies (--user=41966:51966, --security-opt=no-new-privileges,
+no --privileged), and --net=none removes the network datapath entirely. The
+only BTF/eBPF collection specs parsed are the trusted ones shipped inside the
+Docker toolchain itself, never anything derived from user source.
+Verdict: Not exploitable. The DoS requires parsing an attacker-supplied BTF
+collection spec; sandboxed user code has no capability to load eBPF programs and
+cannot reach the vulnerable loadRawSpec path, and only trusted toolchain specs
+are ever parsed. The real fix is bumping cilium/ebpf to 0.22.0+.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (curl/libcurl low-severity batch added 2026-07-03)
+Generated: 2026-06-01 (curl/libcurl low-severity batch added 2026-07-03; cilium/ebpf/btf added 2026-07-04)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -45,6 +45,7 @@ CVE-2026-27136         golang.org/x/net/html    5.3   No   only docker-buildx li
 CVE-2026-42502         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25681         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25680         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML parsed
+CVE-2026-10722         cilium/ebpf/btf          4.8   No   sandboxed user code lacks CAP_BPF to load eBPF; only trusted toolchain BTF specs parsed; DoS only
 curl 18 CVEs (below)   Alpine curl < 8.21.0-r0  low   No   curl CLI removed; libcurl only via git (no net transport used); --net=none; see SNYK-ALPINE324-CURL.txt
 
 == curl / libcurl low-severity batch (Alpine 3.24 apk "curl" < 8.21.0-r0) ==


### PR DESCRIPTION
…6-08-03

  CVE-2026-10722 (SNYK-GOLANG-GITHUBCOMCILIUMEBPFBTF-17810931) is an integer
  overflow in cilium/ebpf/btf's loadRawSpec. It reaches the runner only as a
  transitive dep of the Docker/containerd/runc toolchain in the dind base image;
  there is no fix we can apply without a base-image bump to cilium/ebpf 0.22.0+.
  It is not exploitable here: loading eBPF needs CAP_BPF/CAP_SYS_ADMIN, which the
  sandbox denies, only trusted toolchain BTF specs are ever parsed, and the impact
  is DoS only. Add an ignore entry plus a docs/vulns assessment, matching how the
  other transitive base-image vulns are handled.

  Also push every .snyk ignore expiry out to 2026-08-03 (30 days), since the whole
  batch was about to lapse on 2026-07-16 and would fail the compliance scan.

  Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>