### PR TITLE
Ignore non-exploitable gRPC-Go transport vuln 18172578

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -270,3 +270,10 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-11T00:00:00.000Z
 
+  # no CVE | gRPC-Go internal/transport | Score 8.8 | Not exploitable: --net=none; no gRPC service exposed; runner configures no xDS RBAC policies
+  SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-23T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578.txt
+++ b/docs/vulns/SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578.txt
@@ -1,0 +1,11 @@
+SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578 | gRPC-Go internal/transport | CVSS 8.8 | High (no CVE assigned)
+What: Incorrect authorization in gRPC-Go's xDS RBAC policy processing plus HTTP/2
+transport handling (< 1.82.1). Crafted policy updates with unsupported matcher
+fields, or NOT rules wrapping unhandled fields, can bypass RBAC deny rules; the
+HTTP/2 path can also bypass rapid-reset mitigations or panic the server.
+For cyber-dojo: User code runs with --net=none and cannot send any network frames
+to anything, let alone a gRPC endpoint. Exploitation requires a network-reachable
+gRPC server, and the RBAC bypass additionally requires xDS-configured RBAC policies.
+The runner exposes no gRPC service and configures no xDS RBAC.
+Verdict: Not exploitable by user code. Relevant only if something in your
+infrastructure exposes a gRPC service (with xDS RBAC) to untrusted callers.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -18,6 +18,7 @@ CVE / ID               Package                 Score  Exploitable?  Reason
 ------------------------------------------------------------------------------
 CVE-2026-39821         golang.org/x/net/idna    9.3   No   runner resolves only trusted endpoints; no user-controlled IDNA input
 CVE-2026-33186         gRPC-Go                  9.1   No   --net=none; no gRPC exposure
+gRPC-transport-18172578 gRPC-Go internal/transport 8.8 No   --net=none; no gRPC service exposed; no xDS RBAC configured
 CVE-2026-53488         containerd CRI labels    8.7   No   dockerd uses moby integration, not the CRI plugin; only trusted images run
 CVE-2026-53488         containerd v2/client     8.7   No   same CVE as above, 2nd package (Snyk 17391516); CRI plugin path unused; only trusted images run
 CVE-2026-29181         OTel baggage+family      8.7   No   --net=none; can't send baggage headers


### PR DESCRIPTION
  Snyk flagged SNYK-GOLANG-GOOGLEGOLANGORGGRPCINTERNALTRANSPORT-18172578
  (gRPC-Go internal/transport, CVSS 8.8). The vuln needs a network-reachable
  gRPC server, and its RBAC-bypass half additionally needs xDS-configured RBAC
  policies. The runner sandboxes user code with --net=none, exposes no gRPC
  service, and configures no xDS RBAC, so no attack path is reachable.

  Add a .snyk ignore entry plus the per-vuln assessment doc and summary-table
  row so the build stays compliant without masking a real exposure.