### PR TITLE
Ignore non-exploitable BuildKit git-source vuln 18269092

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -277,3 +277,10 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-23T00:00:00.000Z
 
+  # CVE-2026-15793 | buildkit source/git | Score 7.3 | Not exploitable: runner never runs BuildKit against user-supplied Dockerfiles/git sources; buildx is a bundled build-time CLI plugin only; --net=none
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOURCEGIT-18269092:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+

--- a/docs/vulns/CVE-2026-15793.txt
+++ b/docs/vulns/CVE-2026-15793.txt
@@ -1,0 +1,16 @@
+CVE-2026-15793 | github.com/moby/buildkit/source/git | CVSS 7.3 | High
+What: Arbitrary argument injection (CWE-88) in BuildKit's git source handler
+(gitSourceHandler.checkoutAsBundle in source/git/bundle.go and getDefaultBranch
+in source/git/source.go, >= 0.30.0 < 0.31.2). A malicious git repository whose
+advertised default branch or bundle ref begins with dash-like option text has
+that ref passed unsanitised to "git fetch", letting the attacker inject git
+options into the build host's git invocation. Triggered when building with
+git.checkoutbundle=true against an attacker-controlled git source.
+For cyber-dojo: The runner never runs "docker build"/BuildKit against user-supplied
+Dockerfiles or git sources, so no untrusted ref ever reaches BuildKit's git handler.
+BuildKit is present only via the docker-buildx CLI plugin bundled in the dind base
+image, a build-time tool the runner does not invoke on untrusted input. User code
+runs with --net=none and cannot reach any git remote.
+Verdict: Not exploitable. Relevant only if you use BuildKit to build images from
+untrusted git sources with git.checkoutbundle=true. Fix arrives when docker-base
+bumps buildx/buildkit to >= 0.31.2.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -30,6 +30,7 @@ CVE-2026-48702         sigstore/rekor pkg/types 8.7   No   server-side DoS; runn
 CVE-2026-39831         x/crypto/ssh             8.6   No   --net=none; client-side; no outbound SSH
 CloudWatch-16316406    aws-sdk-go-v2 CloudWatch 8.2   No   --net=none; DoS only; requires MITM of TLS
 CVE-2026-24051         OTel SDK resource        7.3   No   macOS-only (ioreg)
+CVE-2026-15793         buildkit source/git      7.3   No   runner never builds from user Dockerfiles/git sources; buildx is a bundled CLI only
 CVE-2026-39827         x/crypto/ssh             7.1   No   --net=none; no SSH server exposed
 CVE-2026-41178         OTel baggage/propagation 6.9   No   Docker toolchain only; dockerd Unix socket; CLI tools, no inbound HTTP
 CVE-2026-39829         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed


### PR DESCRIPTION
    Snyk flagged SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOURCEGIT-18269092
    (CVE-2026-15793, buildkit source/git, CVSS 7.3). The flaw injects git
    options via a malicious repo whose default branch or bundle ref starts
    with dash-like text, but only when BuildKit fetches that source during a
    build with git.checkoutbundle=true. The runner never runs docker build /
    BuildKit against user-supplied Dockerfiles or git sources; buildx is only
    a bundled build-time CLI plugin, and user code runs --net=none, so no
    untrusted ref ever reaches the affected handler.

    Add a .snyk ignore entry plus the per-vuln assessment doc and summary-table
    row so the build stays compliant without masking a real exposure.