### PR TITLE
Ignore non-exploitable BuildKit executor/oci vuln 18165790

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -284,3 +284,10 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-24T00:00:00.000Z
 
+  # CVE-2026-15788 | buildkit executor/oci | Score 5.6 | Not exploitable: Windows-only (WCOW NTFS-junction cache-mount escape); runner is Linux/alpine and never runs BuildKit against user-supplied build sources; buildx is a bundled build-time CLI plugin only
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITEXECUTOROCI-18165790:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+

--- a/docs/vulns/CVE-2026-15788.txt
+++ b/docs/vulns/CVE-2026-15788.txt
@@ -1,0 +1,17 @@
+CVE-2026-15788 | github.com/moby/buildkit/executor/oci | CVSS 5.6 | Medium
+What: Improper link resolution (CWE-59) in BuildKit's WCOW cache mount source
+selector (executor/oci, >= 0.30.0 < 0.31.2). On Windows Containers on Windows
+(WCOW) the cache mount source selector resolves NTFS junctions in the cache
+mount source path outside the intended cache root, so an attacker with build
+authoring capabilities can use NTFS junctions to escape the cache directory and
+read arbitrary files accessible to the BuildKit daemon. Requires the daemon to
+process an untrusted build source on a Windows host.
+For cyber-dojo: Doubly not applicable. The vulnerable code path is Windows-only
+(WCOW / NTFS junctions); the runner is a Linux/alpine image, so the affected
+selector never runs. Independently, the runner never runs "docker build"/BuildKit
+against user-supplied Dockerfiles or build sources; BuildKit is present only via
+the docker-buildx CLI plugin bundled in the dind base image, a build-time tool the
+runner does not invoke on untrusted input. User code runs with --net=none.
+Verdict: Not exploitable. Relevant only if you use BuildKit to build images from
+untrusted sources on Windows (WCOW). Fix arrives when docker-base bumps
+buildx/buildkit to >= 0.31.2.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -40,6 +40,7 @@ CVE-2026-14362         hashicorp/memberlist     6.9   No   Swarm gossip DoS; run
 CVE-2026-49834         sigstore-go pkg/verify   5.9   No   multi-log threshold bypass; needs N>1 logs + compromised log; bundled cosign uses threshold 1
 CVE-2026-50195         containerd CRI checkpoint 5.6  No   CRI checkpoint import (Kubernetes); dockerd uses moby integration; not K8s; only trusted images (GHSA: Critical)
 CVE-2026-50195         containerd v2/client     5.6   No   same CVE as above, 2nd package (Snyk 17393922); CRI checkpoint path unused; not K8s; only trusted images (GHSA: Critical)
+CVE-2026-15788         buildkit executor/oci    5.6   No   Windows-only (WCOW NTFS-junction escape); runner is Linux; never builds from user sources; buildx is a bundled CLI only
 CVE-2026-39828         x/crypto/ssh             5.3   No   --net=none; no SSH server exposed
 CVE-2026-46595         x/crypto/ssh             5.3   No   --net=none; no SSH server exposed
 CVE-2026-39832         x/crypto/ssh/agent       5.3   No   --net=none; no SSH agent exposed


### PR DESCRIPTION
      Snyk flagged SNYK-GOLANG-GITHUBCOMMOBYBUILDKITEXECUTOROCI-18165790
      (CVE-2026-15788, buildkit executor/oci, CVSS 5.6). The flaw is an
      NTFS-junction symlink attack (CWE-59) in the WCOW cache mount source
      selector: on Windows Containers on Windows a build author can escape the
      cache root and read files accessible to the BuildKit daemon. It is doubly
      inapplicable to the runner. The vulnerable path is Windows-only and the
      runner is a Linux/alpine image, so it never runs; and the runner never runs
      docker build / BuildKit against user-supplied sources anyway (buildx is only
      a bundled build-time CLI plugin, and user code runs --net=none).

      Add a .snyk ignore entry plus the per-vuln assessment doc and summary-table
      row so the build stays compliant without masking a real exposure.