### PR TITLE
Ignore non-exploitable BuildKit solver/llbsolver vuln 18265271

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -291,3 +291,10 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-24T00:00:00.000Z
 
+  # CVE-2026-15792 | buildkit solver/llbsolver/ops | Score 6.0 | Not exploitable: DoS crash of the BuildKit daemon via a malicious frontend/LLB definition; runner never runs BuildKit against user-supplied build definitions; buildx is a bundled build-time CLI plugin only; --net=none
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPS-18265271:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+

--- a/docs/vulns/CVE-2026-15792.txt
+++ b/docs/vulns/CVE-2026-15792.txt
@@ -1,0 +1,18 @@
+CVE-2026-15792 | github.com/moby/buildkit/solver/llbsolver/ops | CVSS 6.0 | Medium
+What: NULL pointer dereference / slice-index panic (CWE-476) in BuildKit's LLB
+solver operation handling (solver/llbsolver/ops, < 0.31.2). By supplying a
+malicious frontend or LLB definition with negative or out-of-range op input
+indices, or by omitting required diff inputs, an attacker with build-authoring
+access can trigger a slice-index panic or nil pointer dereference during load
+and cache-key computation, crashing the BuildKit daemon (denial of service).
+Requires the daemon to process an untrusted LLB definition.
+For cyber-dojo: Not applicable. The runner never runs "docker build"/BuildKit
+against user-supplied Dockerfiles or LLB definitions; BuildKit is present only
+via the docker-buildx CLI plugin bundled in the dind base image, a build-time
+tool the runner does not invoke on untrusted input. User code runs with
+--net=none, so it cannot reach the BuildKit daemon to submit an LLB definition
+in the first place. The impact is a DoS on a component the runner does not
+expose to attacker-controlled input.
+Verdict: Not exploitable. Relevant only if you feed untrusted frontends/LLB
+definitions to a reachable BuildKit daemon. Fix arrives when docker-base bumps
+buildx/buildkit to >= 0.31.2.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -37,6 +37,7 @@ CVE-2026-39829         x/crypto/ssh             6.9   No   --net=none; no SSH se
 CVE-2026-39834         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-39830         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-14362         hashicorp/memberlist     6.9   No   Swarm gossip DoS; runner runs no swarm; no gossip listener (7946/9094) bound
+CVE-2026-15792         buildkit solver/llbsolver 6.0  No   daemon-crash DoS via malicious LLB def; runner never builds from user sources; buildx is a bundled CLI only; --net=none
 CVE-2026-49834         sigstore-go pkg/verify   5.9   No   multi-log threshold bypass; needs N>1 logs + compromised log; bundled cosign uses threshold 1
 CVE-2026-50195         containerd CRI checkpoint 5.6  No   CRI checkpoint import (Kubernetes); dockerd uses moby integration; not K8s; only trusted images (GHSA: Critical)
 CVE-2026-50195         containerd v2/client     5.6   No   same CVE as above, 2nd package (Snyk 17393922); CRI checkpoint path unused; not K8s; only trusted images (GHSA: Critical)


### PR DESCRIPTION
  Snyk flagged SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPS-18265271
  (CVE-2026-15792, buildkit solver/llbsolver/ops, CVSS 6.0). The flaw is a
  NULL pointer dereference / slice-index panic (CWE-476) in the LLB solver:
  a malicious frontend or LLB definition with negative or out-of-range op
  input indices (or missing diff inputs) triggers a panic during load and
  cache-key computation, crashing the BuildKit daemon (denial of service).
  It requires the daemon to process an untrusted LLB definition, which the
  runner never does. The runner never runs docker build / BuildKit against
  user-supplied Dockerfiles or LLB definitions (buildx is only a bundled
  build-time CLI plugin), and user code runs --net=none so it cannot reach
  the daemon to submit a definition at all.

  Add a .snyk ignore entry plus the per-vuln assessment doc and summary-table
  row so the build stays compliant without masking a real exposure.