### PR TITLE
Ignore non-exploitable BuildKit opsutils vuln 18265270

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -298,3 +298,10 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-24T00:00:00.000Z
 
+  # CVE-2026-15792 | buildkit solver/llbsolver/ops/opsutils | Score 6.0 | Not exploitable: same CVE as 18265271 attributed to a second buildkit package; DoS crash of the BuildKit daemon via a malicious frontend/LLB definition; runner never runs BuildKit against user-supplied build definitions; buildx is a bundled build-time CLI plugin only; --net=none
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPSOPSUTILS-18265270:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPSOPSUTILS-18265270.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPSOPSUTILS-18265270.txt
@@ -1,0 +1,23 @@
+SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPSOPSUTILS-18265270 | github.com/moby/buildkit/solver/llbsolver/ops/opsutils | CVSS 6.0 | Medium | CVE-2026-15792
+What: This is the same advisory as CVE-2026-15792 (Snyk
+SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPS-18265271, see
+CVE-2026-15792.txt), which Snyk attributes to a second import path in the
+buildkit module: NULL pointer dereference / slice-index panic (CWE-476) in
+BuildKit's LLB solver operation handling. A malicious frontend or LLB
+definition with negative or out-of-range op input indices, or one omitting
+required diff inputs, triggers a slice-index panic or nil pointer dereference
+during load and cache-key computation, crashing the BuildKit daemon (denial of
+service). Both packages are flagged because the fix ships at the module level
+(identical fixed versions). Requires the daemon to process an untrusted LLB
+definition.
+Fix available: buildkit 0.31.2 (vulnerable: <0.31.2).
+For cyber-dojo: Not applicable, for the same reasons as the ops package. The
+runner never runs "docker build"/BuildKit against user-supplied Dockerfiles or
+LLB definitions; BuildKit is present only via the docker-buildx CLI plugin
+bundled in the dind base image, a build-time tool the runner does not invoke on
+untrusted input. User code runs with --net=none, so it cannot reach the BuildKit
+daemon to submit an LLB definition in the first place. The impact is a DoS on a
+component the runner does not expose to attacker-controlled input.
+Verdict: Not exploitable. Relevant only if you feed untrusted frontends/LLB
+definitions to a reachable BuildKit daemon. Fix arrives when docker-base bumps
+buildx/buildkit to >= 0.31.2, which clears this advisory alongside 18265271.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24; buildkit solver/llbsolver/ops/opsutils 18265270 (same CVE-2026-15792) added 2026-07-24)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -38,6 +38,7 @@ CVE-2026-39834         x/crypto/ssh             6.9   No   --net=none; no SSH se
 CVE-2026-39830         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-14362         hashicorp/memberlist     6.9   No   Swarm gossip DoS; runner runs no swarm; no gossip listener (7946/9094) bound
 CVE-2026-15792         buildkit solver/llbsolver 6.0  No   daemon-crash DoS via malicious LLB def; runner never builds from user sources; buildx is a bundled CLI only; --net=none
+CVE-2026-15792         buildkit opsutils        6.0   No   same CVE as above, 2nd package (Snyk 18265270); daemon-crash DoS via malicious LLB def; runner never builds from user sources; --net=none
 CVE-2026-49834         sigstore-go pkg/verify   5.9   No   multi-log threshold bypass; needs N>1 logs + compromised log; bundled cosign uses threshold 1
 CVE-2026-50195         containerd CRI checkpoint 5.6  No   CRI checkpoint import (Kubernetes); dockerd uses moby integration; not K8s; only trusted images (GHSA: Critical)
 CVE-2026-50195         containerd v2/client     5.6   No   same CVE as above, 2nd package (Snyk 17393922); CRI checkpoint path unused; not K8s; only trusted images (GHSA: Critical)


### PR DESCRIPTION
    Snyk flagged SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPSOPSUTILS-18265270,
    which is the same advisory as 18265271 (CVE-2026-15792, CVSS 6.0) attributed to
    a second buildkit import path: solver/llbsolver/ops/opsutils. Both packages are
    flagged because the fix ships at the module level (buildkit 0.31.2).

    The flaw is a NULL pointer dereference / slice-index panic (CWE-476) in the LLB
    solver: a malicious frontend or LLB definition with negative or out-of-range op
    input indices (or missing diff inputs) panics during load and cache-key
    computation, crashing the BuildKit daemon (denial of service). It requires the
    daemon to process an untrusted LLB definition, which the runner never does. The
    runner never runs docker build / BuildKit against user-supplied Dockerfiles or
    LLB definitions (buildx is only a bundled build-time CLI plugin), and user code
    runs --net=none so it cannot reach the daemon to submit a definition at all.

    Add a .snyk ignore entry plus a per-vuln assessment doc named after the Snyk ID
    (cross-referencing CVE-2026-15792.txt) and a summary-table row, following the
    same convention used for the two containerd packages of CVE-2026-50195, so the
    build stays compliant without masking a real exposure.