### PR TITLE
Ignore two non-exploitable BuildKit vulns 18265269 and 18269949

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -305,3 +305,17 @@ ignore:
         expires: 2026-08-10T10:53:10.182Z
         created: 2026-07-24T00:00:00.000Z
 
+  # CVE-2026-15792 | buildkit solver/llbsolver | Score 6.0 | Not exploitable: same CVE as 18265271 attributed to a third buildkit package; DoS crash of the BuildKit daemon via a malicious frontend/LLB definition; runner never runs BuildKit against user-supplied build definitions; buildx is a bundled build-time CLI plugin only; --net=none
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVER-18265269:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+
+  # CVE-2026-15791 | buildkit solver/llbsolver/file | Score 1.8 | Not exploitable: fileop path traversal deleting files outside the build root; runner never runs BuildKit against user-supplied build definitions; buildx is a bundled build-time CLI plugin only; --net=none
+  SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVERFILE-18269949:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-10T10:53:10.182Z
+        created: 2026-07-24T00:00:00.000Z
+

--- a/docs/vulns/CVE-2026-15791.txt
+++ b/docs/vulns/CVE-2026-15791.txt
@@ -1,0 +1,18 @@
+CVE-2026-15791 | github.com/moby/buildkit/solver/llbsolver/file | CVSS 1.8 | Low
+What: Directory traversal (CWE-22) in BuildKit's fileop handling. The deletion
+target of a file operation is normalised with filepath.Clean but parent
+traversal is still permitted, so a crafted LLB fileop can escape the fileop root
+and delete files outside the build root (for example reaching /tmp contents on
+the build host). Requires the BuildKit daemon to load an attacker-crafted LLB
+definition / API request; scored Low (1.8) because the attack vector is local and
+needs user interaction to run the malicious build.
+Fix available: buildkit 0.31.2 (vulnerable: <0.31.2).
+For cyber-dojo: The runner never runs "docker build"/BuildKit against
+user-supplied Dockerfiles or LLB definitions, so no attacker-crafted fileop ever
+reaches the solver. BuildKit is present only via the docker-buildx CLI plugin
+bundled in the dind base image, a build-time tool the runner does not invoke on
+untrusted input. User code runs with --net=none and cannot reach the BuildKit
+daemon to submit a fileop at all. Sandbox working directories are tmpfs mounts
+created per run, not shared build roots.
+Verdict: Not exploitable. Relevant only if you build images from untrusted LLB
+definitions. Fix arrives when docker-base bumps buildx/buildkit to >= 0.31.2.

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVER-18265269.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVER-18265269.txt
@@ -1,0 +1,24 @@
+SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVER-18265269 | github.com/moby/buildkit/solver/llbsolver | CVSS 6.0 | Medium | CVE-2026-15792
+What: This is the same advisory as CVE-2026-15792 (Snyk
+SNYK-GOLANG-GITHUBCOMMOBYBUILDKITSOLVERLLBSOLVEROPS-18265271, see
+CVE-2026-15792.txt), which Snyk attributes to a third import path in the
+buildkit module: NULL pointer dereference / slice-index panic (CWE-476) in
+BuildKit's LLB solver operation handling. A malicious frontend or LLB
+definition with negative or out-of-range op input indices, or one omitting
+required diff inputs, triggers a slice-index panic or nil pointer dereference
+during load and cache-key computation, crashing the BuildKit daemon (denial of
+service). All three packages are flagged because the fix ships at the module
+level (identical fixed versions). Requires the daemon to process an untrusted
+LLB definition.
+Fix available: buildkit 0.31.2 (vulnerable: <0.31.2).
+For cyber-dojo: Not applicable, for the same reasons as the ops and opsutils
+packages. The runner never runs "docker build"/BuildKit against user-supplied
+Dockerfiles or LLB definitions; BuildKit is present only via the docker-buildx
+CLI plugin bundled in the dind base image, a build-time tool the runner does not
+invoke on untrusted input. User code runs with --net=none, so it cannot reach the
+BuildKit daemon to submit an LLB definition in the first place. The impact is a
+DoS on a component the runner does not expose to attacker-controlled input.
+Verdict: Not exploitable. Relevant only if you feed untrusted frontends/LLB
+definitions to a reachable BuildKit daemon. Fix arrives when docker-base bumps
+buildx/buildkit to >= 0.31.2, which clears this advisory alongside 18265271 and
+18265270.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24; buildkit solver/llbsolver/ops/opsutils 18265270 (same CVE-2026-15792) added 2026-07-24)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24; buildkit solver/llbsolver/ops/opsutils 18265270 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver 18265269 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver/file CVE-2026-15791 added 2026-07-24)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -37,8 +37,9 @@ CVE-2026-39829         x/crypto/ssh             6.9   No   --net=none; no SSH se
 CVE-2026-39834         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-39830         x/crypto/ssh             6.9   No   --net=none; no SSH server exposed
 CVE-2026-14362         hashicorp/memberlist     6.9   No   Swarm gossip DoS; runner runs no swarm; no gossip listener (7946/9094) bound
-CVE-2026-15792         buildkit solver/llbsolver 6.0  No   daemon-crash DoS via malicious LLB def; runner never builds from user sources; buildx is a bundled CLI only; --net=none
+CVE-2026-15792         buildkit llbsolver/ops   6.0   No   daemon-crash DoS via malicious LLB def; runner never builds from user sources; buildx is a bundled CLI only; --net=none
 CVE-2026-15792         buildkit opsutils        6.0   No   same CVE as above, 2nd package (Snyk 18265270); daemon-crash DoS via malicious LLB def; runner never builds from user sources; --net=none
+CVE-2026-15792         buildkit llbsolver       6.0   No   same CVE as above, 3rd package (Snyk 18265269); daemon-crash DoS via malicious LLB def; runner never builds from user sources; --net=none
 CVE-2026-49834         sigstore-go pkg/verify   5.9   No   multi-log threshold bypass; needs N>1 logs + compromised log; bundled cosign uses threshold 1
 CVE-2026-50195         containerd CRI checkpoint 5.6  No   CRI checkpoint import (Kubernetes); dockerd uses moby integration; not K8s; only trusted images (GHSA: Critical)
 CVE-2026-50195         containerd v2/client     5.6   No   same CVE as above, 2nd package (Snyk 17393922); CRI checkpoint path unused; not K8s; only trusted images (GHSA: Critical)
@@ -53,6 +54,7 @@ CVE-2026-42502         golang.org/x/net/html    5.3   No   only docker-buildx li
 CVE-2026-25681         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25680         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML parsed
 CVE-2026-10722         cilium/ebpf/btf          4.8   No   sandboxed user code lacks CAP_BPF to load eBPF; only trusted toolchain BTF specs parsed; DoS only
+CVE-2026-15791         buildkit llbsolver/file  1.8   No   fileop path traversal deletes outside build root; runner never builds from user sources; buildx is a bundled CLI only
 
 == curl / libcurl low-severity batch: removed 2026-07-04 ==
 


### PR DESCRIPTION
  Both surfaced in the runner's latest snyk-aws-beta-per-artifact attestation.
  Reviewing that attestation rather than only the reported ID showed .snyk was
  short two entries, not one, so both are added together.

  18265269 is CVE-2026-15792 again, attributed to a third package in the buildkit
  module (solver/llbsolver) alongside the already-ignored llbsolver/ops 18265271
  and opsutils 18265270. All three clear at once when docker-base bumps buildkit
  to >= 0.31.2.

  18269949 is a distinct advisory, CVE-2026-15791: a fileop path traversal that
  can delete files outside the build root.

  Neither is reachable here. The runner never runs BuildKit against user-supplied
  Dockerfiles or LLB definitions; buildx is only a build-time CLI plugin bundled
  in the dind base image, and sandboxed user code runs with --net=none so it
  cannot submit a build definition to the daemon at all.

  The llbsolver/ops summary row was labelled "buildkit solver/llbsolver", which
  becomes ambiguous now that the real solver/llbsolver package has its own row.