### PR TITLE
Ignore non-exploitable sigstore-go expired-key vuln 18508018

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -319,3 +319,10 @@ ignore:
         expires: 2026-08-26T10:53:10.182Z
         created: 2026-07-24T00:00:00.000Z
 
+  # CVE-2026-54787 | sigstore-go pkg/verify | Score 2.3 | Not exploitable: expired-key acceptance when verifying self-managed public-key bundles with ExpiringKey semantics; runner performs no sigstore bundle verification at runtime; cosign is build-time tooling only
+  SNYK-GOLANG-GITHUBCOMSIGSTORESIGSTOREGOPKGVERIFY-18508018:
+    - '*':
+        reason: Not exploitable in runner context; see docs/vulns/readme.txt
+        expires: 2026-08-26T10:53:10.182Z
+        created: 2026-08-04T00:00:00.000Z
+

--- a/docs/vulns/SNYK-GOLANG-GITHUBCOMSIGSTORESIGSTOREGOPKGVERIFY-18508018.txt
+++ b/docs/vulns/SNYK-GOLANG-GITHUBCOMSIGSTORESIGSTOREGOPKGVERIFY-18508018.txt
@@ -1,0 +1,28 @@
+SNYK-GOLANG-GITHUBCOMSIGSTORESIGSTOREGOPKGVERIFY-18508018 | github.com/sigstore/sigstore-go/pkg/verify | CVSS 2.3 | Low | CVE-2026-54787
+What: An expired-key acceptance flaw in sigstore-go's verification path. In
+pkg/verify/signed_entity.go the verifier fails to enforce the key validity
+window when checking bundles that carry ExpiringKey semantics, so a signature
+whose timestamp falls outside that window is still accepted. An attacker who
+holds a key that has since expired (or a stale bundle signed with one) can
+therefore have a forged or out-of-date signature verify successfully when it
+should be rejected. The flaw is confined to self-managed public-key-signed
+bundles; bundles verified through certificates are unaffected, because the
+certificate chain carries its own validity checking. Impact is integrity only.
+Attack vector Network, complexity High, privileges Low, no user interaction.
+Fix available: sigstore-go 1.2.1 (vulnerable: < 1.2.1).
+For cyber-dojo: github.com/sigstore/sigstore-go/pkg/verify is part of the
+sigstore signature-verification toolchain; it is linked transitively through the
+Docker image-signing and attestation toolchain (cosign / docker buildx) bundled
+in the dind image, not through any code cyber-dojo writes. The runner performs
+no sigstore bundle verification at runtime: it starts and stops sandbox
+containers from images that are pulled and pinned ahead of time, and it never
+asks cosign to verify a bundle, let alone one signed with a self-managed
+expiring public key. There is consequently no verification decision for an
+expired key to subvert. User code runs inside a sandbox container with
+--net=none, --user=41966:51966 and --security-opt=no-new-privileges, so it
+cannot reach any network endpoint, supply a bundle to a verifier, or influence
+any signature-verification policy.
+Verdict: Not exploitable. The flaw only matters to a verifier that checks
+public-key-signed bundles with ExpiringKey semantics; the runner runs no such
+verification and the bundled cosign is build-time tooling that the runner never
+invokes at runtime. The real fix is bumping sigstore-go to 1.2.1+.

--- a/docs/vulns/readme.txt
+++ b/docs/vulns/readme.txt
@@ -1,5 +1,5 @@
 CVE Assessment: docker:29.4.1-dind-alpine3.23 for cyber-dojo
-Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24; buildkit solver/llbsolver/ops/opsutils 18265270 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver 18265269 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver/file CVE-2026-15791 added 2026-07-24)
+Generated: 2026-06-01 (cilium/ebpf/btf added 2026-07-04; curl/libcurl batch removed 2026-07-04 -- git deleted from the runner image, see below; sigstore-go pkg/verify and hashicorp/memberlist added 2026-07-11; gRPC-Go internal/transport 18172578 added 2026-07-23; buildkit source/git CVE-2026-15793 added 2026-07-24; buildkit executor/oci CVE-2026-15788 added 2026-07-24; buildkit solver/llbsolver/ops CVE-2026-15792 added 2026-07-24; buildkit solver/llbsolver/ops/opsutils 18265270 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver 18265269 (same CVE-2026-15792) added 2026-07-24; buildkit solver/llbsolver/file CVE-2026-15791 added 2026-07-24; sigstore-go pkg/verify 18508018 CVE-2026-54787 added 2026-08-04)
 
 Each vulnerability has its own file in this directory named after its CVE or Snyk ID.
 
@@ -54,6 +54,7 @@ CVE-2026-42502         golang.org/x/net/html    5.3   No   only docker-buildx li
 CVE-2026-25681         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML rendered
 CVE-2026-25680         golang.org/x/net/html    5.3   No   only docker-buildx links html pkg; build-time CLI; no untrusted HTML parsed
 CVE-2026-10722         cilium/ebpf/btf          4.8   No   sandboxed user code lacks CAP_BPF to load eBPF; only trusted toolchain BTF specs parsed; DoS only
+CVE-2026-54787         sigstore-go pkg/verify   2.3   No   expired-key acceptance for self-managed public-key bundles; runner verifies no bundles; cosign is build-time tooling only
 CVE-2026-15791         buildkit llbsolver/file  1.8   No   fileop path traversal deletes outside build root; runner never builds from user sources; buildx is a bundled CLI only
 
 == curl / libcurl low-severity batch: removed 2026-07-04 ==


### PR DESCRIPTION
  CVE-2026-54787 lets a verifier accept a signature made after its key
  expired, but only for self-managed public-key bundles using ExpiringKey
  semantics. The runner verifies no sigstore bundles at runtime; sigstore-go
  is only linked transitively via the cosign/buildx build-time tooling in the
  dind base image. Nothing in the runner makes the verification decision the
  flaw subverts, so there is no path to exploit.

  Expiry matches the rest of the file (2026-08-26), by when the base image
  should carry sigstore-go 1.2.1+ and the ignore can be dropped.