### PR TITLE
Compress runner payloads at gzip level 1

### DIFF
--- a/docs/profiling/check_gzip_level_1_flag_support.sh
+++ b/docs/profiling/check_gzip_level_1_flag_support.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Report whether this image's gzip(1) accepts -1, and whether what it writes
+# still round-trips.
+#
+# time_tgz_vs_tar_emit.sh shows -1 costing about a third of the default level
+# while keeping most of the compression, which makes it the cheap way to keep
+# gzip's CRC32 and length trailer. That measurement was taken on one image, so
+# it says nothing about portability. This probe is the one that does: it prints
+# a single line per image so a host-side loop over every image reads as a table.
+#
+# Portability here is not a given. GNU gzip rejects -0, and the Alpine images
+# ship busybox applets whose flag support differs from GNU's, exactly as
+# busybox xargs rejects --null while accepting -0.
+#
+# Short options throughout, against this repo's usual preference for long ones:
+# busybox rejects --version, --delete, --bytes and --silent outright, and a
+# probe that dies on the very images whose portability is in question reports
+# nothing where it matters most.
+set -eu
+
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/probe_lib.sh"
+
+probe_help_check "${1:-}" "Usage: check_gzip_level_1_flag_support.sh
+
+Prints one line: OS, gzip version, whether -1 and -0 are accepted, and whether
+a -1 stream round-trips. Exits non-zero if -1 fails or the round-trip differs.
+Run inside a language image:
+
+  docker run --rm --entrypoint=\"\" --volume \$PWD:/probe:ro \\
+    ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd \\
+    bash /probe/check_gzip_level_1_flag_support.sh
+
+To survey every locally pulled language image:
+
+  for img in \$(docker images --format '{{.Repository}}:{{.Tag}}' \\
+                | grep cyber-dojo-languages | sort); do
+    printf '%-58s ' \"\${img}\"
+    docker run --rm --entrypoint=\"\" --volume \$PWD:/probe:ro \"\${img}\" \\
+      bash /probe/check_gzip_level_1_flag_support.sh 2>&1 | tail -1
+  done"
+
+readonly DIR=/tmp/probe_gzip_level_1_flag_support
+
+rm -rf "${DIR}"
+mkdir -p "${DIR}"
+cd "${DIR}"
+
+# Real text rather than zeroes, so a level that silently stores rather than
+# deflates is still visible in the byte count.
+cat /etc/services /etc/passwd /etc/group > plain.txt 2>/dev/null || true
+if [ ! -s plain.txt ]; then
+  i=0
+  while [ "${i}" -lt 500 ]; do
+    echo 'the quick brown fox jumps over the lazy dog' >> plain.txt
+    i=$(( i + 1 ))
+  done
+fi
+
+os='unknown'
+if [ -r /etc/os-release ]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  os="${ID:-unknown}${VERSION_ID:+:${VERSION_ID}}"
+fi
+
+# busybox gzip has no --version and exits non-zero when given one, so the
+# version is whatever the first line of that attempt says, and the applet is
+# named separately from the version it claims.
+version="$(gzip --version 2>&1 | head -1 | tr -d '\n' || true)"
+case "${version}" in
+  *BusyBox*|*busybox*|*'unrecognized option'*|*'invalid option'*|*Usage*)
+    version="busybox ($(busybox 2>&1 | head -1 | cut -d' ' -f1-2 || echo unknown))"
+    ;;
+esac
+
+# Reports whether gzip accepts the level at all, separately from whether what
+# it wrote can be read back, because those fail in different ways.
+level_accepted()
+{
+  gzip "${1}" -c plain.txt > /dev/null 2>&1
+}
+
+if level_accepted -1; then level_1=yes; else level_1=no; fi
+if level_accepted -0; then level_0=yes; else level_0=no; fi
+
+round_trip=n/a
+ratio=n/a
+if [ "${level_1}" = yes ]; then
+  gzip -1 -c plain.txt > level1.gz
+  if gzip -d -c level1.gz | cmp -s - plain.txt; then
+    round_trip=ok
+  else
+    round_trip=DIFFERS
+  fi
+  plain_bytes=$(wc -c < plain.txt)
+  gz_bytes=$(wc -c < level1.gz)
+  if [ "${gz_bytes}" -gt 0 ]; then
+    ratio="$(( plain_bytes / gz_bytes ))x"
+  fi
+fi
+
+printf '%-14s %-34s -1=%-4s -0=%-4s round_trip=%-8s ratio=%s\n' \
+  "${os}" "${version}" "${level_1}" "${level_0}" "${round_trip}" "${ratio}"
+
+cd /
+rm -rf "${DIR}"
+
+[ "${level_1}" = yes ] && [ "${round_trip}" = ok ]

--- a/docs/profiling/time_container_stdout_throughput.sh
+++ b/docs/profiling/time_container_stdout_throughput.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -Eeu -o pipefail
+# Measures what the runner saves by receiving fewer bytes.
+#
+# The gzip in send_tgz() buys nothing but a smaller payload on the path
+# container -> daemon -> docker CLI -> runner. That saving is only worth having
+# if those bytes are expensive, so this probe prices them: it emits payloads of
+# several sizes from a container's stdout and reads them on the host, exactly as
+# capture3_with_timeout.rb does.
+#
+# Subtracting the empty-payload run from each row leaves the transfer cost
+# alone, with container startup, which dominates it, removed.
+
+readonly MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${MY_DIR}/probe_lib.sh"
+
+probe_help_check "${1:-}" \
+"Usage: docs/profiling/time_container_stdout_throughput.sh [-h] [IMAGE]
+
+Times docker run reading payloads of several sizes from a container's stdout,
+and prints the transfer cost with container startup subtracted out.
+
+Options:
+  -h    Show this help
+
+Example:
+  docs/profiling/time_container_stdout_throughput.sh ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd"
+
+readonly IMAGE="${1:-ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd}"
+readonly RUNS=5
+
+# Emits KB kilobytes on stdout from a tmpfs file, so the measurement is the
+# transfer and not the reading of a disk.
+emit()
+{
+  local -r kb="${1}"
+  docker run --rm --tmpfs /tmp:exec,size=250M,mode=1777 --entrypoint='' "${IMAGE}" \
+    bash -c "dd if=/dev/zero of=/tmp/payload bs=1024 count=${kb} status=none; cat /tmp/payload"
+}
+
+# Prints the mean wall-clock of RUNS emits of KB kilobytes, with the caller's
+# baseline subtracted.
+time_emit()
+{
+  local -r kb="${1}" baseline_us="${2}"
+  local i
+  local -r t0=${EPOCHREALTIME/./}
+  for (( i = 0; i < RUNS; i++ )); do emit "${kb}" > /dev/null; done
+  local -r t1=${EPOCHREALTIME/./}
+  local -r mean_us=$(( (t1 - t0) / RUNS ))
+  printf '%10s KB %12s us %12s us\n' "${kb}" "${mean_us}" "$(( mean_us - baseline_us ))"
+  MEAN_US=${mean_us}
+}
+
+probe_environment
+echo "image: ${IMAGE}"
+probe_preflight docker run --rm --entrypoint='' "${IMAGE}" bash -c 'true'
+
+printf '%13s %15s %15s\n' payload 'docker run' 'minus startup'
+MEAN_US=0
+time_emit 0 0
+readonly BASELINE_US=${MEAN_US}
+time_emit 8 "${BASELINE_US}"     # a typical kata, gzipped
+time_emit 40 "${BASELINE_US}"    # a typical kata, not gzipped
+time_emit 640 "${BASELINE_US}"   # the 50-file ceiling, gzipped
+time_emit 2560 "${BASELINE_US}"  # the 50-file ceiling, not gzipped

--- a/docs/profiling/time_tgz_vs_tar_emit.sh
+++ b/docs/profiling/time_tgz_vs_tar_emit.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -Eeu -o pipefail
+# Measures the container half of the question "is gzip worth it?".
+#
+# send_tgz() in home_files.rb ends with [gzip < "${TAR_FILE}"], so every
+# traffic-light compresses the whole sandbox before the runner sees a byte of
+# it. The pipe is local (container -> daemon -> docker CLI -> runner), so the
+# compression buys no network time; it trades container CPU, and host CPU to
+# inflate it again, for fewer bytes through the daemon socket.
+#
+# This probe times the emit step alone. The tar file is built once per payload
+# profile and reused, because building it is common to both variants and is not
+# what is in question. It reports the byte counts too, since those are what a
+# no-gzip variant would have to push through the socket instead.
+#
+# The host half of the question (Zlib inflate + untar versus untar alone) is a
+# separate measurement, as is the end-to-end docker run.
+#
+# Payload profiles span what a kata returns: a handful of small source files at
+# one end, and at the other 50 files, which is the practical ceiling, several of
+# them at the 50KB per-file truncation cap.
+
+readonly MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${MY_DIR}/probe_lib.sh"
+
+probe_help_check "${1:-}" \
+"Usage: docs/profiling/time_tgz_vs_tar_emit.sh [-h] [IMAGE]
+
+Times [gzip < tar] against [cat tar] inside a language image, for several
+sandbox payload sizes, and prints the bytes each variant emits.
+
+Options:
+  -h    Show this help
+
+Example:
+  docs/profiling/time_tgz_vs_tar_emit.sh ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd"
+
+readonly IMAGE="${1:-ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd}"
+
+# Mirrors the tmpfs the runner gives the container, so the tar file being read
+# and the payload being written live in memory here as they do in production.
+readonly TMP_FS='--tmpfs /tmp:exec,size=250M,mode=1777'
+
+readonly PROBE=$(cat <<'SHELL'
+set -eu
+readonly RUNS=10
+readonly CORPUS=/tmp/corpus
+readonly CORPUS_KB=8192
+
+# Real source text, so the compression ratio is one a kata could actually see.
+# Zeroes would compress to nothing and flatter gzip; random bytes would not
+# compress at all and flatter cat.
+#
+# The doubling is bounded, and an empty seed is a hard error: an image that
+# keeps its python somewhere this find does not reach would otherwise leave the
+# loop doubling nothing forever.
+build_corpus()
+{
+  find /usr /lib -name '*.py' -type f 2>/dev/null | head -n 200 | xargs cat > "${CORPUS}"
+  if [ "$(stat -c %s "${CORPUS}")" -lt 1024 ]; then
+    echo 'ERROR: no source text found to build a corpus from' >&2
+    exit 1
+  fi
+  local i
+  for (( i = 0; i < 20; i++ )); do
+    if [ "$(stat -c %s "${CORPUS}")" -ge $(( CORPUS_KB * 1024 )) ]; then
+      return
+    fi
+    cat "${CORPUS}" "${CORPUS}" > "${CORPUS}.2"
+    mv "${CORPUS}.2" "${CORPUS}"
+  done
+}
+
+# Each file takes a different slice of the corpus. Identical files would sit
+# inside gzip's 32KB window and dedupe against each other, which would report a
+# compression ratio no real sandbox achieves. dd seeks to its slice, where a
+# tail|head pair would re-read the whole corpus once per file.
+build_sandbox()
+{
+  local -r count="${1}" size_kb="${2}"
+  local i
+  rm -rf /tmp/sandbox
+  mkdir -p /tmp/sandbox
+  for (( i = 0; i < count; i++ )); do
+    dd if="${CORPUS}" of="/tmp/sandbox/file_${i}.py" \
+       bs=1024 skip=$(( i * (size_kb + 7) % (CORPUS_KB - size_kb) )) count="${size_kb}" \
+       status=none
+  done
+}
+
+time_emit()
+{
+  local -r name="${1}" count="${2}" size_kb="${3}"
+  build_sandbox "${count}" "${size_kb}"
+  tar -cf /tmp/out.tar -C /tmp sandbox
+
+  local i
+  local -r t0=${EPOCHREALTIME/./}
+  for (( i = 0; i < RUNS; i++ )); do cat     < /tmp/out.tar > /dev/null; done
+  local -r t1=${EPOCHREALTIME/./}
+  for (( i = 0; i < RUNS; i++ )); do gzip    < /tmp/out.tar > /dev/null; done
+  local -r t2=${EPOCHREALTIME/./}
+  for (( i = 0; i < RUNS; i++ )); do gzip -1 < /tmp/out.tar > /dev/null; done
+  local -r t3=${EPOCHREALTIME/./}
+
+  local -r cat_us=$(( (t1 - t0) / RUNS ))
+  local -r gzip_us=$(( (t2 - t1) / RUNS ))
+  local -r gzip1_us=$(( (t3 - t2) / RUNS ))
+  local -r tar_bytes=$(stat -c %s /tmp/out.tar)
+  local -r gz_bytes=$(gzip < /tmp/out.tar | wc -c)
+  local -r gz1_bytes=$(gzip -1 < /tmp/out.tar | wc -c)
+
+  printf '%-9s %4s x %4sK %9s %9s %9s %8s %8s %8s\n' \
+    "${name}" "${count}" "${size_kb}" \
+    "${tar_bytes}" "${gz_bytes}" "${gz1_bytes}" \
+    "${cat_us}" "${gzip_us}" "${gzip1_us}"
+}
+
+build_corpus
+printf '%-9s %12s %9s %9s %9s %8s %8s %8s\n' \
+  profile files 'tar bytes' 'gz bytes' 'gz1 bytes' 'cat us' 'gzip us' 'gzip1 us'
+time_emit typical  12   2
+time_emit medium   40  10
+time_emit large    16  50
+time_emit ceiling  50  50
+SHELL
+)
+
+probe_environment
+echo "image: ${IMAGE}"
+probe_preflight docker run --rm ${TMP_FS} --entrypoint='' "${IMAGE}" bash -c 'true'
+docker run --rm ${TMP_FS} --entrypoint='' "${IMAGE}" bash -c "${PROBE}"

--- a/docs/profiling/time_tgz_vs_tar_parse.rb
+++ b/docs/profiling/time_tgz_vs_tar_parse.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Measures the runner half of the question "is gzip worth it?".
+#
+# runner.rb reaches its files through TGZ.files(tgz_out), which inflates the
+# whole payload with Zlib and then walks it with Gem::Package::TarReader. Only
+# the inflate is in question here, so each payload is parsed both ways and the
+# difference is the price the runner pays for the container having compressed.
+#
+# Run by time_tgz_vs_tar_parse.sh, which supplies the payloads and a ruby whose
+# architecture matches the host, since emulation would inflate exactly the CPU
+# cost being measured.
+
+require '/repo/source/server/gnu_zip'
+require '/repo/source/server/tgz'
+require '/repo/source/server/tarfile_reader'
+
+RUNS = 10
+
+# Returns the mean seconds per call of running the block RUNS times.
+def mean_seconds(&block)
+  t0 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  RUNS.times(&block)
+  t1 = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  (t1 - t0) / RUNS
+end
+
+# Returns microseconds, rounded, for a seconds duration.
+def micros(seconds)
+  (seconds * 1_000_000).round
+end
+
+# Prints one table row, the first cell left aligned and the rest right aligned.
+def print_row(cells)
+  head, *tail = cells
+  puts(head.to_s.ljust(10) + tail.map { |cell| cell.to_s.rjust(12) }.join)
+end
+
+# Prints one row comparing inflate-plus-untar against untar alone.
+def time_parse(name, tar)
+  tgz = Gnu.zip(tar)
+  tgz_us = micros(mean_seconds { TGZ.files(tgz) })
+  tar_us = micros(mean_seconds { TarFile::Reader.new(tar.dup).files })
+  print_row([name, tar.size, tgz.size, tar_us, tgz_us, tgz_us - tar_us])
+end
+
+# Prints the table header, naming the two parses being compared.
+def print_header
+  print_row(['profile', 'tar bytes', 'gz bytes', 'tar us', 'tgz us', 'gzip cost'])
+end
+
+print_header
+ARGV.each do |path|
+  time_parse(File.basename(path, '.tar'), File.binread(path))
+end

--- a/docs/profiling/time_tgz_vs_tar_parse.sh
+++ b/docs/profiling/time_tgz_vs_tar_parse.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -Eeu -o pipefail
+# Supplies time_tgz_vs_tar_parse.rb with payloads and a ruby to measure in.
+#
+# The payloads are built in a language image by the same rule as
+# time_tgz_vs_tar_emit.sh uses, so the two halves of the gzip question are
+# measured over the same bytes and their costs can be added.
+#
+# The ruby runs in a stock ruby image rather than the runner image, because the
+# runner image is amd64 and would be emulated on an arm64 host, inflating the
+# Zlib inflate that is the thing being measured.
+
+readonly MY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_DIR="$(cd "${MY_DIR}/../.." && pwd)"
+source "${MY_DIR}/probe_lib.sh"
+
+probe_help_check "${1:-}" \
+"Usage: docs/profiling/time_tgz_vs_tar_parse.sh [-h] [IMAGE]
+
+Times TGZ.files(tgz) against TarFile::Reader alone, over sandbox payloads
+built in IMAGE, and prints the microseconds gzip adds to the runner.
+
+Options:
+  -h    Show this help
+
+Example:
+  docs/profiling/time_tgz_vs_tar_parse.sh ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd"
+
+readonly IMAGE="${1:-ghcr.io/cyber-dojo-languages/python_pytest:e8d7fcd}"
+readonly RUBY_IMAGE=ruby:3.4-alpine
+readonly PAYLOAD_DIR="$(mktemp -d)"
+
+readonly BUILDER=$(cat <<'SHELL'
+set -eu
+readonly CORPUS=/tmp/corpus
+readonly CORPUS_KB=8192
+
+build_corpus()
+{
+  find /usr /lib -name '*.py' -type f 2>/dev/null | head -n 200 | xargs cat > "${CORPUS}"
+  if [ "$(stat -c %s "${CORPUS}")" -lt 1024 ]; then
+    echo 'ERROR: no source text found to build a corpus from' >&2
+    exit 1
+  fi
+  local i
+  for (( i = 0; i < 20; i++ )); do
+    if [ "$(stat -c %s "${CORPUS}")" -ge $(( CORPUS_KB * 1024 )) ]; then
+      return
+    fi
+    cat "${CORPUS}" "${CORPUS}" > "${CORPUS}.2"
+    mv "${CORPUS}.2" "${CORPUS}"
+  done
+}
+
+build_payload()
+{
+  local -r name="${1}" count="${2}" size_kb="${3}"
+  local i
+  rm -rf /tmp/sandbox
+  mkdir -p /tmp/sandbox
+  for (( i = 0; i < count; i++ )); do
+    dd if="${CORPUS}" of="/tmp/sandbox/file_${i}.py" \
+       bs=1024 skip=$(( i * (size_kb + 7) % (CORPUS_KB - size_kb) )) count="${size_kb}" \
+       status=none
+  done
+  tar -cf "/payload/${name}.tar" -C /tmp sandbox
+}
+
+build_corpus
+build_payload typical 12  2
+build_payload medium  40 10
+build_payload large   16 50
+build_payload ceiling 50 50
+SHELL
+)
+
+probe_environment
+echo "image: ${IMAGE}"
+echo "ruby:  ${RUBY_IMAGE}"
+
+docker run --rm \
+  --tmpfs /tmp:exec,size=250M,mode=1777 \
+  --volume "${PAYLOAD_DIR}:/payload" \
+  --entrypoint='' "${IMAGE}" bash -c "${BUILDER}"
+
+docker run --rm \
+  --volume "${REPO_DIR}:/repo:ro" \
+  --volume "${PAYLOAD_DIR}:/payload:ro" \
+  "${RUBY_IMAGE}" \
+  ruby /repo/docs/profiling/time_tgz_vs_tar_parse.rb \
+    /payload/typical.tar /payload/medium.tar /payload/large.tar /payload/ceiling.tar
+
+rm -rf "${PAYLOAD_DIR}"

--- a/docs/profiling/where-the-traffic-light-time-goes.txt
+++ b/docs/profiling/where-the-traffic-light-time-goes.txt
@@ -1,0 +1,190 @@
+Where the traffic-light time goes
+=================================
+
+A review of the run path in runner.rb, capture3_with_timeout.rb and
+home_files.rb, asking one question: what stands between the learner pressing
+the test button and the traffic-light lighting up, and what does not have to
+be there.
+
+The measurements come from three probes in this directory:
+
+  time_tgz_vs_tar_emit.sh            container side of the gzip question
+  time_tgz_vs_tar_parse.sh (+ .rb)   runner side of the gzip question
+  time_container_stdout_throughput.sh  what fewer bytes are worth
+  check_gzip_level_1_flag_support.sh   whether -1 is portable across images
+
+Measurement conditions
+----------------------
+arm64 host, Docker Desktop, language image ghcr.io/cyber-dojo-languages/
+python_pytest:e8d7fcd, which is arm64 and so runs natively. The ruby half runs
+in ruby:3.4-alpine rather than the runner image, because the runner image is
+amd64 and emulating it inflates the very CPU cost being measured.
+
+Production is amd64 on Linux with no VM boundary, so treat the ratios here as
+portable and the absolute numbers as not. In particular the container startup
+figure below is a Docker Desktop figure and is pessimistic.
+
+Payload profiles are 12x2K, 40x10K, 16x50K and 50x50K. 50 files is the
+practical ceiling on what a kata returns, and 50K is the per-file truncation
+cap in runner.rb.
+
+
+What is on the critical path
+----------------------------
+1. Container create and start.
+2. Untar of the incoming files, then cyber-dojo.sh itself.
+3. The exit trap: binary-file scan, truncation, tar, gzip.
+4. Transfer of the payload to the runner over the daemon socket.
+5. Inflate and untar in the runner, then the rag-lambda.
+6. Container teardown. capture3_with_timeout.rb reads stdout to EOF in a
+   thread but the result waits on waiter.value, which is the docker CLI
+   exiting, which is after --rm has removed the container.
+
+Steps 1 and 6 are the container lifecycle. Neither has to be on the path.
+
+
+Finding: compression is worth its CRC, not its bytes, so it runs at level 1
+---------------------------------------------------------------------------
+send_tgz() compresses the payload. The pipe is local, so that buys no network
+time. It trades CPU in the container, plus CPU in the runner to inflate it
+again, for fewer bytes through the daemon socket, and for gzip's CRC32 and
+length trailer. The bytes turn out not to be worth much; the CRC is, and
+level 1 is the cheap way to keep it.
+
+Container side, microseconds, gzip cost is the difference:
+
+  profile             files  tar bytes   gz bytes     cat us    gzip us  gzip cost
+  typical       12 x     2K      40960       8159        299        740        441
+  medium        40 x    10K     440320     101757        307       7917       7610
+  large         16 x    50K     829440     206673        326      15689      15363
+  ceiling       50 x    50K    2590720     649720        597      47478      46881
+
+Runner side, TGZ.files against TarFile::Reader alone:
+
+  profile       tar bytes     gz bytes     tar us     tgz us  gzip cost
+  typical           40960         7866         55        243        188
+  medium           440320        97914        352       1264        912
+  large            829440       198890        254       2226       1972
+  ceiling         2590720       625154        815       7041       6226
+
+Combined cost of compressing: 0.6ms typical, 8.5ms medium, 17.3ms large,
+53.1ms at the ceiling. Compression is about 4x on real source text.
+
+What the saved bytes are worth, from a container's stdout to the host, with the
+empty-payload run subtracted to remove startup:
+
+        payload      docker run   minus startup
+           0 KB       153078 us       153078 us
+          40 KB       150500 us        -2578 us   typical, plain
+           8 KB       150844 us        -2234 us   typical, gzipped
+        2560 KB       178098 us        25020 us   ceiling, plain
+         640 KB       155839 us         2761 us   ceiling, gzipped
+
+Run-to-run noise is about 2.5ms, so at typical sizes the transfer saving is
+not measurable at all. At the ceiling it is 25.0 - 2.8 = 22.2ms, against a
+53.1ms cost.
+
+So the default level is a bad deal: no compression at all is about 0.5ms
+faster on a typical kata and about 31ms faster at the ceiling. But sending a
+bare tar gives up the only integrity check in the payload, and that check
+cannot be given up. See the next section.
+
+Level 1 is what makes the check affordable. Same probe, same payloads:
+
+  profile          files tar bytes  gz bytes gz1 bytes   cat us  gzip us gzip1 us
+  typical     12 x    2K     40960      8159      9272      241      676      474
+  medium      40 x   10K    440320    101761    124305      277     7052     3226
+  large       16 x   50K    829440    206679    252515      329    14226     6743
+  ceiling     50 x   50K   2590720    649646    789570      357    42535    18456
+
+Level 1 costs about a third of the default and still compresses 3.3x. Adding
+emit, transfer and runner parse, the ceiling comes to roughly 26ms for a bare
+tar, 29ms at level 1, and 52ms at the default. The integrity check therefore
+costs about 3ms at the ceiling and 0.4ms on a typical kata.
+
+GNU gzip rejects -0, so level 1 is as cheap as gzip goes.
+check_gzip_level_1_flag_support.sh surveyed 103 language images: alpine 3.11
+to 3.24 (busybox 1.31 to 1.37), debian 9 to 13, ubuntu 18.04 to 24.04. Every
+one accepts -1, rejects -0, and round-trips. Both directions run at level 1:
+send_tgz() in home_files.rb and Gnu.zip in gnu_zip.rb.
+
+
+Why the CRC cannot be given up
+------------------------------
+Gem::Package::TarHeader.from verifies neither the header checksum nor the
+ustar magic: it requires only that a few fields match /\A[0-7]*\z/ once
+stripped, and the empty string matches. Bytes that are not a tar therefore
+parse into entries with junk names, and those names and contents would be
+returned to the browser as created files. Measured directly: a corrupt payload
+came back as an amber traffic-light carrying a file named "r".
+
+Rubygems offers no strict mode, and minitar does not verify checksums either
+(it does enforce the magic, raising Minitar::InvalidTarStream). So the tar
+layer alone cannot be trusted, and TarFile::Reader checks the ustar magic on
+every entry, raising Gem::Package::TarInvalidError otherwise.
+
+That leaves two checks, and both are pinned:
+  run_faulty_gzip_error_test.rb  payload is not a gzip stream, Zlib rejects it
+  run_faulty_tar_error_test.rb   payload inflates to something that is not a tar
+
+Note the second only fires for payloads short enough that rubygems' own octal
+check passes. That is exactly the lenient case the ustar check exists for.
+
+Truncation is a separate matter and is still undetected. The streams are tarred
+before the sandbox files, so a truncated payload keeps tmp/status and loses
+trailing files. Catching it means requiring the two 512-byte zero blocks that
+end an archive, which Gem's reader does not.
+
+
+Finding: container startup dwarfs everything else
+-------------------------------------------------
+An empty container costs 153ms here. Every millisecond above is small beside
+it. Two changes take the lifecycle off the critical path:
+
+  Reply at stdout EOF. The payload is complete when the container's stdout
+  closes. The remaining wait is only the docker CLI exiting after --rm. Reap
+  it in a thread instead. The one dependency is run[:status], which runner.rb
+  uses to spot a faulty run. A payload that parses and contains tmp/status is
+  itself proof the run was fine, so the real status need only be consulted
+  when the payload is missing or unusable, or when the run timed out.
+
+  Pre-start containers per hot image. The container blocks on [tar -zxf -]
+  reading stdin, so create, start and tmpfs mount can all happen before the
+  learner presses anything. Writing the payload to stdin becomes the trigger,
+  and the timeout clock starts there. Each container is still used exactly
+  once and then discarded, so isolation is unchanged, and a pool miss simply
+  falls back to a cold start.
+
+Doing the first creates the seam the second needs: the reap path stops being
+"wait for --rm" and becomes "hand the container back".
+
+
+Ruled out: sending the traffic-light early on container stderr
+--------------------------------------------------------------
+The container's stderr carries nothing (runner.rb only logs it on failure), so
+it looked free for stdout/stderr/status, letting the colour be computed before
+the sandbox file-walk, tar and gzip finished. It does not help: the response to
+the browser has to carry the created, changed and deleted file data with the
+colour, and cannot be split. Nothing can be answered early while the rest is
+still being collected.
+
+
+Not measured: per-avatar build state
+------------------------------------
+Every run starts from a fresh tmpfs, so every run recompiles from cold. For a
+compiled language that dominates all of the above. Keeping build artifacts
+between successive runs is the largest available win and the largest change.
+
+The unit has to be the avatar, not the kata. Several avatars work the same
+kata and their files differ, so a cache they shared would be wrong, not merely
+slow. The runner cannot key one today: the only identifier it receives is id,
+documented in docs/api.md as being for tracing, and it names the kata. So this
+starts with an API change, and then needs instance affinity, a reaper for
+abandoned avatars, and it gives up a sandbox that starts clean every time.
+
+
+Loose ends
+----------
+The corpus and sandbox builders are duplicated between the two gzip probes.
+They have to agree for the two halves to be addable, so they belong in
+probe_lib.sh.

--- a/source/server/gnu_zip.rb
+++ b/source/server/gnu_zip.rb
@@ -2,9 +2,17 @@ require 'stringio'
 require 'zlib'
 
 module Gnu
+  # Compresses at level 1, matching send_tgz() in home_files.rb.
+  #
+  # The pipe to the container is local, so the smaller payload buys almost no
+  # transfer time; what gzip is here for is its CRC32 and length trailer,
+  # which is what makes the container's [tar -zxf -] reject a payload that
+  # did not arrive intact. Level 1 costs about a third of the default level
+  # and keeps most of the compression.
+  # See docs/profiling/where-the-traffic-light-time-goes.txt
   def self.zip(str)
     zipped = StringIO.new
-    writer = Zlib::GzipWriter.new(zipped)
+    writer = Zlib::GzipWriter.new(zipped, Zlib::BEST_SPEED)
     writer.write(str)
     writer.close
     zipped.string

--- a/source/server/home_files.rb
+++ b/source/server/home_files.rb
@@ -22,6 +22,17 @@ module HomeFiles
   # into a tgz file which becomes the container's stdout
   # which is read in capture3_with_timeout.rb
   #
+  # Compression is at level 1. The pipe to the runner is local, so the
+  # smaller payload buys almost no transfer time; what gzip is here for is
+  # its CRC32 and length trailer. A tar alone has no integrity check that
+  # Ruby will act on, and garbage bytes parse into entries with junk names
+  # that would reach the browser. Level 1 costs about a third of the default
+  # level and keeps most of the compression, and every language image
+  # accepts it: docs/profiling/check_gzip_level_1_flag_support.sh surveyed
+  # alpine 3.11 to 3.24, debian 9 to 13 and ubuntu 18.04 to 24.04. Level 0
+  # is not an option; GNU gzip rejects it.
+  # See docs/profiling/where-the-traffic-light-time-goes.txt
+  #
   # There are important comments on the exit-status of
   # cyber_dojo_main.sh at the end of capture3_with_timeout.rb
   #
@@ -85,7 +96,7 @@ module HomeFiles
         truncate_large_files
         tar -rf "${TAR_FILE}" /tmp/stdout /tmp/stderr /tmp/status
         print0_filenames | tar -rf "${TAR_FILE}" --verbatim-files-from --null -T - # [0]
-        gzip  < "${TAR_FILE}"
+        gzip -1 < "${TAR_FILE}"
       }
       function remove_binary_files()
       {

--- a/source/server/runner.rb
+++ b/source/server/runner.rb
@@ -2,6 +2,7 @@ require_relative 'capture3_with_timeout'
 require_relative 'files_delta'
 require_relative 'home_files'
 require_relative 'sandbox'
+require_relative 'tarfile_reader'
 require_relative 'tgz'
 require_relative 'traffic_light'
 require_relative 'utf8_clean'
@@ -43,9 +44,13 @@ class Runner
       Sandbox.out(at_most(16, created)),
       Sandbox.out(changed)
     )
-  rescue Zlib::GzipFile::Error
-    log(id: id, image_name: image_name, error: 'Zlib::GzipFile::Error')
-    empty_result(:gzip_error, 'faulty', {})
+  rescue Zlib::GzipFile::Error, Gem::Package::TarInvalidError => e
+    # Zlib rejects a payload whose gzip CRC32 or length trailer does not
+    # match; TarFile::Reader rejects one that inflates to something which is
+    # not a tar. Either way the container did not send a run result, and
+    # nothing in it may reach the browser.
+    log(id: id, image_name: image_name, error: e.class.name)
+    empty_result(:corrupt_payload, 'faulty', {})
   end
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -
@@ -68,7 +73,7 @@ class Runner
     pulling: 141,
     timed_out: 142,
     faulty: 143,
-    gzip_error: 144
+    corrupt_payload: 144
   }.freeze
 
   private

--- a/source/server/tarfile_reader.rb
+++ b/source/server/tarfile_reader.rb
@@ -4,16 +4,35 @@ require 'stringio'
 module TarFile
   class Reader
     def initialize(tar_file)
-      io = StringIO.new(tar_file, 'r+t')
+      io = StringIO.new(tar_file, 'rb')
       @reader = Gem::Package::TarReader.new(io)
     end
 
     def files
       @reader.each.with_object({}) do |entry, memo|
+        check_ustar(entry)
         filename = entry.full_name
         content = entry.read || '' # avoid nil
         memo[filename] = content
       end
     end
+
+    private
+
+    # Raises unless the entry carries the ustar magic.
+    #
+    # Gem::Package::TarHeader.from verifies neither the header checksum nor
+    # the magic. It requires only that a few fields match /\A[0-7]*\z/ once
+    # stripped, and the empty string matches, so bytes that are not a tar at
+    # all can parse into entries with junk names. The magic is what holds
+    # them out.
+    def check_ustar(entry)
+      magic = entry.header.magic
+      return if magic == USTAR
+
+      raise Gem::Package::TarInvalidError, "#{magic.inspect} is not #{USTAR.inspect}"
+    end
+
+    USTAR = 'ustar'.freeze
   end
 end

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -25,21 +25,21 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=', 102 ],
+    [ 'test.count',    stats['test_count'],    '>=', 104 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '<=',  0 ],
     [ 'test.errors',   stats['error_count'  ], '<=',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '<=',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 944 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 976 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '<=', 0   ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '<=', 0   ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '<=', 0   ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 564 ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 572 ],
     [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=', 0   ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 70  ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 72  ],
     [ 'code.branches.missed',  code_cov['branches']['missed'], '<=', 0   ],
   ]
 end

--- a/test/server/home_files_gzip_level_test.rb
+++ b/test/server/home_files_gzip_level_test.rb
@@ -1,0 +1,21 @@
+require_relative '../test_base'
+require_code 'home_files'
+require_code 'sandbox'
+
+class HomeFilesGzipLevelTest < TestBase
+
+  include HomeFiles
+
+  test '4Ef2a9', %w[the container compresses its stdout at gzip level 1] do
+    script = main_sh(Sandbox::DIR, Runner::MAX_FILE_SIZE)
+
+    assert_includes script, 'gzip -1 < "${TAR_FILE}"', script
+  end
+
+  # Level 1 is the whole point of the flag: the compression is incidental on a
+  # local pipe, the CRC32 and length trailer are what stop a corrupt payload
+  # reaching the browser, and the default level costs three times as much to
+  # get them. Losing the -1 would be invisible except as a slower traffic
+  # light, which is why it is pinned here.
+  # See docs/profiling/where-the-traffic-light-time-goes.txt
+end

--- a/test/server/run_faulty_tar_error_test.rb
+++ b/test/server/run_faulty_tar_error_test.rb
@@ -1,27 +1,32 @@
 require_relative '../test_base'
 
-class RunFaultyGzipErrorTest < TestBase
+class RunFaultyTarErrorTest < TestBase
 
-  test 'c7Dd54', %w[outcome is faulty when the container's stdout is not a gzip stream] do
-    stub_gzip_error
+  test 'Bc4a9F', %w[outcome is faulty when the payload inflates to something that is not a tar] do
+    stub_tar_error
 
     run_cyber_dojo_sh
 
     assert faulty?, run_result
     assert_equal '144', status, run_result
+    assert_equal({}, created, run_result)
     lines = @logger.logged.lines
     assert_equal 1, lines.size
     assert_json_line(lines[0], {
                        id: id58,
                        image_name: image_name,
-                       error: 'Zlib::GzipFile::Error'
+                       error: 'Gem::Package::TarInvalidError'
                      })
   end
 
   private
 
-  def stub_gzip_error
-    stdout_tgz = 'not-a-tgz'
+  # Gem::Package::TarHeader verifies neither the header checksum nor the ustar
+  # magic, so bytes like these parse into entries with junk names. The names
+  # and their contents would reach the browser as created files, which is what
+  # TarFile::Reader's ustar check exists to stop.
+  def stub_tar_error
+    stdout_tgz = Gnu.zip('not-a-tar')
     stderr = ''
     set_context(
       logger: @logger = StdoutLoggerSpy.new,


### PR DESCRIPTION
  The pipe between runner and container is local, so compression buys
  almost no transfer time. What it buys is gzip's CRC32 and length
  trailer, and that is not optional: rubygems' tar reader verifies
  neither the header checksum nor the ustar magic, so bytes that are not
  a tar parse into entries with junk names which would be returned to
  the browser as created files. A corrupt payload came back as an amber
  traffic-light carrying a file named "r".

  Level 1 keeps that check at a third of the cost of the default level,
  still compressing 3.3x. At the 50-file ceiling the integrity check now
  costs about 3ms, and about 0.4ms on a typical kata. Level 0 is not
  available; GNU gzip rejects it.

  TarFile::Reader also checks the ustar magic per entry, so a payload
  that inflates cleanly but is not a tar is faulty rather than silently
  misread.

  docs/profiling/where-the-traffic-light-time-goes.txt records the
  measurements, the probes that produced them, and the survey of all 103
  language images confirming -1 works on alpine 3.11-3.24, debian 9-13
  and ubuntu 18.04-24.04.