### PR TITLE
Refuse image names that name no one image, and recover when one goes …

### DIFF
--- a/bin/setup_dependent_images.sh
+++ b/bin/setup_dependent_images.sh
@@ -7,14 +7,20 @@ setup_dependent_images()
   remove_pulled_image
 }
 
+# Must match any_image_without_bash in test/client/container_properties_test.rb
+readonly ALPINE_WITHOUT_BASH=alpine:3.24
+
 pull_dependent_images()
 {
   echo
   echo Pulling images used in server-side tests
   local -r IMAGE_NAMES=$(docker image ls --format '{{.Repository}}:{{.Tag}}' | sort | uniq)
-  if ! echo "${IMAGE_NAMES}" | grep alpine:latest ; then
-    # alpine:latest is used for tests showing bash must be in the image_name
-    docker pull --platform linux/amd64 alpine:latest
+  if ! echo "${IMAGE_NAMES}" | grep "${ALPINE_WITHOUT_BASH}" ; then
+    # Used by the test showing bash must be in the image_name.
+    # Pinned to a version because the runner refuses an unversioned
+    # image_name, and because a test naming :latest is a test whose
+    # subject can change without the test changing.
+    docker pull --platform linux/amd64 "${ALPINE_WITHOUT_BASH}"
   fi
 
   local -r DISPLAY_NAMES="$(

--- a/docs/a-missing-image-recovers-only-through-puller.md
+++ b/docs/a-missing-image-recovers-only-through-puller.md
@@ -1,0 +1,120 @@
+# A missing image recovers only through Puller
+
+Since the run path moved to the daemon socket, Puller is the only thing that
+puts an image on a node. Nothing else pulls, and the daemon will not pull on
+the runner's behalf. That is fine while Puller's bookkeeping is right, and
+unrecoverable when it is not.
+
+## The daemon does not pull
+
+POST /containers/create answers 404 for an image the node does not have. It
+takes a container config plus name and platform, and carries no pull-if-missing
+option, so there is no flag to set. Probed against the daemon rather than read
+from the docs, on Docker 29.7.2, API 1.55, 2026-08-27:
+
+    curl --unix-socket /var/run/docker.sock --request POST \
+      --header "Content-Type: application/json" \
+      --data '{"Image":"cyberdojo/definitely-absent-image:nope"}' \
+      http://localhost/containers/create
+
+    {"message":"No such image: cyberdojo/definitely-absent-image:nope"}
+    HTTP_CODE=404
+
+`docker run` appears to pull because the CLI implements pull-on-404 itself,
+client-side, and then retries the create. That logic lived in the CLI, so
+running cyber-dojo.sh over the socket left it behind.
+
+## What still recovers
+
+runner.rb consults Puller on every test-run, not only at kata creation:
+
+    return empty_result(:pulling, 'pulling', {}) unless
+      puller.pull_image(id: id, image_name: image_name) == :pulled
+
+So an image nobody has pulled does recover. The first test-run answers
+"pulling" to the browser, a thread pulls, and a later press gets a traffic
+light. That is the self-heal, and it is Puller's, not the daemon's.
+
+## @pulled is seeded from the node, not from pulling
+
+config.ru fills it before the first request:
+
+    context.node.image_names.each do |image_name|
+      context.puller.add(image_name)
+    end
+
+So most of what @pulled holds was never pulled by this process. It is a
+snapshot of `docker image ls` taken when puma started, which on the machine
+this was checked on was 176 names. Puma preloads, so the seed runs once in the
+master and every forked worker starts from the same snapshot, then diverges as
+each pulls on its own. That is why restarting is the current escape from the
+stale state: the restart re-seeds.
+
+It also means the stale window opens at boot rather than at the first pull.
+Anything that removes an image after puma starts is invisible to @pulled.
+
+The two paths agree on the key, which is worth knowing because they reach it
+differently: config.ru adds the raw image-ls name, while pull_image tags the
+manifest name through ::Docker.tagged_image_name. Checked against a real node's
+176 names, tagging is the identity on all of them, and no start-point manifest
+uses a digest, which is the form where the two would diverge.
+
+One name did not survive tagging. node.rb filters the exact string
+'<none>:<none>' but not a name like repo/name:<none>, where the repository is
+set and the tag is not. tagged_image_name raises NoMethodError on that, its
+regex having matched nothing. Such a name is nothing to do with cyber-dojo: it
+is whatever else the host happens to have built.
+
+Nothing hits it today, because puller.rb:20 is the only caller of
+tagged_image_name and it tags manifest names, never seeded ones: the junk name
+sits in @pulled and matches nothing. It stops being harmless as soon as
+anything tags a seeded name, which is what the fix below would do. So the
+filter in node.rb wants widening to any name whose tag is <none>, in the same
+change.
+
+## What does not recover
+
+What does not recover is an image Puller believes is present and is not.
+@pulled is add-only: puller.rb calls @pulled.add, never delete, though
+SynchronizedSet#delete exists and @pulling uses it. Once an image name is in
+there, pull_image answers :pulled forever. If the image then leaves the node,
+every test-run for it does this:
+
+  1. pull_image answers :pulled, so runner.rb goes on rather than pulling
+  2. DaemonRun#create gets 404 and raises DaemonRefused
+  3. runner.rb rescues it, logs, and answers faulty_result({})
+
+There is no path out. Nothing re-pulls, because the only pull is gated behind
+the cache that is wrong. The learner gets a faulty traffic light on every press
+until that puma worker restarts, which is what empties @pulled.
+
+## How an image leaves a node under Puller's feet
+
+Not hypothetically. docs/purge-stale-images.txt plans exactly this: delete
+images by age, driven off @pulled. Kubernetes does it too, without asking,
+through kubelet image garbage collection. Either one produces the state above.
+
+## The fix is pull-on-404, in the same place the CLI had it
+
+Catch the 404 from create, POST /images/create, retry the create once. That is
+the CLI's logic moved back in, and it is what makes a wrong @pulled survivable
+rather than terminal: the create that 404s is proof the image has gone, so the
+same handler can @pulled.delete(image_name) and let the eager path work
+correctly from then on.
+
+Note what this does not do. It does not make Puller redundant. Puller's job is
+to pull at kata creation so the first test-run is fast, and pull-on-404 is a
+recovery path for when that bookkeeping is wrong, on a run that is already
+going to be slow. Both are wanted.
+
+## Bearing on the other plans
+
+docs/pre-started-container-pool.md gains a second caller of create, in a
+background thread. A stale @pulled currently costs one visible faulty result
+per press; with a pool it also costs a refill thread 404ing quietly for an
+image that is gone. The pool wants the same invalidation, and its create is
+another good place to notice the 404.
+
+docs/dropping-the-dind-base-image.md converts Puller's `docker pull` to POST
+/images/create. Whoever does that owns the streaming-progress error handling
+this fix also needs, so the two belong in one change.

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,8 +9,10 @@ Runs `/sandbox/cyber-dojo.sh` for at most **manifest**'s **max_seconds**.
   * **id:String** for tracing
   * **files:Hash{filename:String => content:String}** assumed to contain a file called `cyber-dojo.sh`
   * **manifest:Hash** containing
-    * **image_name:String** created with [image_builder](https://github.com/cyber-dojo-tools/image_builder)
+    * **image_name:String** created with [image_builder](https://github.com/cyber-dojo-tools/image_builder), and [pinned to a version](#image_name)
     * **max_seconds:Integer** between `1` and `20`
+    * **rag_lambda:String** the source of the Ruby lambda deciding the traffic light.
+      Omitting it is [deprecated](#rag_lambda)
   * eg
     ```json
     { "id": "34de2W",
@@ -61,9 +63,12 @@ Runs `/sandbox/cyber-dojo.sh` for at most **manifest**'s **max_seconds**.
 - `"outcome"` equals `"pulling"` if **image_name** is not present on the node.
 - `"outcome"` equals `"timed_out"` if `cyber-dojo.sh` failed to complete in **max_seconds**.
 - `"outcome"` equals `"red"`, `"amber"`, `"green"`,
-    as determined by passing `stdout['content']`, `stderr['content']`, `status` to the Ruby lambda, read from **image_name**, at `/usr/local/bin/red_amber_green.rb`
+    as determined by passing `stdout['content']`, `stderr['content']`, `status` to a Ruby lambda.
+    The lambda comes from **manifest**'s **rag_lambda**.
+    With no **rag_lambda**, it is read from **image_name**, at `/usr/local/bin/red_amber_green.rb`,
+    which is [deprecated](#rag_lambda).
 - `"outcome"` equals `"faulty"` (and adds information to **log**) if
-  * `/usr/local/bin/red_amber_green.rb` does not exist in **image_name**
+  * there is no **rag_lambda** and `/usr/local/bin/red_amber_green.rb` does not exist in **image_name**
   * eval'ing the lambda raises an exception
   * calling the lambda raises an exception
   * the lambda returns anything other than `red`, `amber`, or `green` (as a string or a symbol)
@@ -73,7 +78,7 @@ Runs `/sandbox/cyber-dojo.sh` for at most **manifest**'s **max_seconds**.
 Pulls **image_name** onto the node if not already present.
 - [JSON-in](#json-in) parameters
   * **id:String** for tracing
-  * **image_name:String**
+  * **image_name:String** [pinned to a version](#image_name)
 - returns the [JSON-out](#json-out) result, keyed on `"pull_image"`
   * `"pulled"` if **image_name** is already present on the node.
   * `"pulling"` if **image_name** is not already present on the node, and pulls the image asynchronously.
@@ -125,6 +130,30 @@ The git commit sha used to create the Docker image.
   {"sha":"41d7e6068ab75716e4c7b9262a3a44323b4d1448"}
   ```
 
+
+- - - -
+## rag_lambda
+- Give the lambda's source in the **manifest**. Reading it from the image is
+  deprecated and will be removed.
+- Reading it from the image costs a whole container run, to read one file,
+  on the first test-run for that image after a restart. The manifest costs
+  nothing.
+- Until it is removed, a **manifest** with no **rag_lambda** still works.
+
+- - - -
+## image_name
+- Must be pinned to a tag other than `latest`,
+  eg `cyberdojofoundation/python_pytest:56fa098`.
+- `:latest` names whichever image was pushed to it last, so a start-point
+  using it can change underneath the kata. The runner will not take one, so
+  that a start-point names one image and keeps naming it. This is refused
+  however it is asked for: written out as `:latest`, left off entirely
+  (which means `:latest`), or left off in front of a digest.
+- A digest may follow the tag, eg `...:56fa098@sha256:1a2b...`.
+- Both methods taking an **image_name** reject a bad one with a 400, before
+  anything is pulled or run.
+  * `"malformed image_name"` if it does not name a docker image at all.
+  * `"unversioned image_name"` if it names one but resolves to `:latest`.
 
 - - - -
 ## JSON in

--- a/docs/dropping-the-dind-base-image.md
+++ b/docs/dropping-the-dind-base-image.md
@@ -1,0 +1,143 @@
+# Dropping the dind base image
+
+The runner's image is built `FROM cyberdojo/docker-base`, which is
+`docker:29.7.2-dind-alpine3.24` plus ruby and a handful of gems. The only thing
+that base supplies which the runner actually uses at runtime is the `docker`
+CLI binary. If the last three CLI callers move to the daemon's HTTP API, the
+runner can be built `FROM ghcr.io/cyber-dojo/sinatra-base` instead, the same as
+saver and the other services.
+
+## Why the daemon socket is not the obstacle
+
+The runner does not run a docker daemon of its own. It talks to the host's
+daemon through the socket bind-mounted by `docker-compose.yml`:
+
+    - /var/run/docker.sock:/var/run/docker.sock
+
+That mount is a compose / task-definition concern. It works regardless of which
+base image the runner is built from, because opening a unix socket needs no
+docker binaries at all: `source/server/externals/unix_socket_http.rb` speaks
+HTTP over the socket directly.
+
+So "runner needs the docker socket" and "runner needs a dind base image" are
+separate claims, and only the first is true.
+
+## The three remaining CLI callers
+
+Each goes through `context.sheller` (`BashSheller`, which is `Open3.capture3`):
+
+| Site | Command | Daemon endpoint |
+| --- | --- | --- |
+| `source/server/node.rb:7` | `docker image ls --format '{{.Repository}}:{{.Tag}}'` | `GET /images/json` |
+| `source/server/puller.rb:37` | `docker pull <image>` | `POST /images/create?fromImage=&tag=` |
+| `source/server/traffic_light.rb:76` | `docker run --rm --entrypoint=cat <image> <rag-lambda-file>` | create + start + attach + remove |
+
+The first two are thin. `GET /images/json` answers each image's `RepoTags`, so
+`image_names` becomes a flatten-and-sort over that array rather than splitting
+lines of CLI output; the `<none>:<none>` entry the CLI prints is simply absent
+from the API's `RepoTags`. `POST /images/create` streams newline-delimited JSON
+progress objects and returns 200 before the pull finishes, so the caller must
+drain the stream to the end and treat a trailing object containing an `error`
+key as failure. The CLI's non-zero exit status has no direct equivalent.
+
+Do that one alongside the pull-on-404 retry in
+`docs/a-missing-image-recovers-only-through-puller.md`. The retry needs a pull
+it can call from `DaemonRun#create`, which is this same `POST /images/create`
+and this same stream-draining, so writing them apart writes them twice.
+
+The third looks like the real work and is not, because it does not have to run
+anything. `docker run --entrypoint=cat` starts a container only to read one
+file back out of it, and the daemon will copy a file out of a container that
+has never been started. So the sequence is three plain `client.request` calls:
+
+    POST   /containers/create              Image only, since it never runs
+    GET    /containers/{id}/archive?path=/usr/local/bin/red_amber_green.rb
+    DELETE /containers/{id}
+
+None of `daemon_run.rb`'s machinery is needed for it. No attach hijack, no
+frame demultiplexing, no stdin to half-close, no deadline, no stop. The archive
+response is a tar, and `TarFile::Reader#files` already parses one and enforces
+the ustar magic, so pulling the single entry out is a line. What replaces
+`checked_read_lambda_source` is on the order of 25 lines, plus a create config
+far smaller than `CyberDojoShContainerConfig` because nothing executes.
+
+It should also be quicker than what it replaces. Nothing starts, and
+profiling/time_docker_run_split.sh puts start at about 48ms of daemon work
+against create at about 16ms. The saving lands on the first test-run for an
+image after a restart, which is where TrafficLight's per-image cache leaves it.
+
+`UnixSocketHttp#request` carries the tar without changes.
+`#attach` sets binmode on its socket and `#request` does not, which looks like
+it would matter and does not: `read_chunked_body` accumulates into `+''`, and
+`socket.read(size)` answers ASCII-8BIT, so the empty buffer adopts ASCII-8BIT
+on the first append and stays binary from there. Verified rather than assumed.
+
+The other branch of `read_body` would not be safe. Plain `socket.read` with no
+length answers the default external encoding, so it would tag tar bytes UTF-8.
+Nothing reaches it: the daemon answers chunked whatever Connection it is asked
+for, which is what the comment above `read_body` records.
+
+Not verified here: that the archive endpoint answers for a container which was
+created and never started. It is how `docker cp` behaves against a stopped
+container, but that is the API's documented behaviour rather than something
+measured in this repo. A probe alongside the others in profiling/ would settle
+it, and is the first thing to write.
+
+How much has to be written depends on how busy that route still is.
+`runner.rb:31` only falls to `colour_from_image` when the manifest carries no
+`rag_lambda`, and `docs/start-points-without-a-manifest-rag-lambda.md` audits
+who that still is: 12 start-points of 83, eleven of them clang or java. Giving
+those twelve a manifest `rag_lambda` empties the route of everything a
+start-point can reach.
+
+It does not empty it of callers. A fork of an old kata, or an image someone
+built themselves, still arrives without the field and cannot be upgraded from
+here. Deleting `colour_from_image` therefore waits on somewhere else to answer
+those, which is the ragger service in `docs/rag-functions-into-manifest.txt`.
+Until that exists this converts by rewrite, and the twelve only decide how
+often the rewritten path runs.
+
+## What sinatra-base gives, and what the switch costs
+
+`sinatra-base` is `ruby:4.0.5-alpine3.24` plus bash, tini, procps, util-linux
+and tar, with its gems bundled in `/app`. That covers everything the runner
+needs once the CLI has no callers: `/sbin/tini` for the `ENTRYPOINT`, bash for
+`config/up.sh` and `config/healthcheck.sh`, busybox `wget` for the healthcheck
+request, tar for tar-piping coverage out of tmpfs.
+
+Points to settle before committing to the change:
+
+- The runner must keep `USER root`, or run as a user in the group owning
+  `/var/run/docker.sock`. Saver drops to an unprivileged `saver` user; the
+  runner cannot do the same without matching that group. See
+  `docs/runner-as-docker-group.txt`.
+- Ruby changes from Alpine's `ruby-dev` package to the official
+  `ruby:4.0.5-alpine3.24` image, and the inherited gem set changes from
+  `docker-base`'s Gemfile to `sinatra-base`'s. Both carry json, puma, rack,
+  thin, prometheus-client, minitest and simplecov. `docker-base` additionally
+  carries coveralls and ruby-prof; `sinatra-base` additionally carries sinatra,
+  nokogiri, capybara and selenium-webdriver. The runner's own
+  `gem install concurrent-ruby` line stays either way.
+- Two `RUN` lines in `Dockerfile` exist only to undo dind and are deleted with
+  it: `apk del git` (git arrives from `docker:dind` and drags in libcurl) and
+  the `rm -rf` of the buildx CLI plugin. Both of their long explanatory
+  comments go too.
+- `docker-base` does not become unused. Commander is still built from it.
+
+## Order of work
+
+1. `node.rb` to `GET /images/json`. Smallest, and `test/server/node_test.rb`
+   pins the behaviour already.
+2. `puller.rb` to `POST /images/create`. Needs a decision on what counts as a
+   failed pull now that there is no exit status.
+3. `traffic_light.rb` to create / archive / delete, after a probe confirms the
+   archive endpoint answers for a container that was never started. Giving the
+   12 start-points a manifest `rag_lambda` is worth doing alongside, because it
+   makes this path rare, but it does not remove the need to write it.
+4. Delete `BashSheller`, `BashShellerStub`, `context.sheller` and their tests.
+5. Rebase the `Dockerfile` on `sinatra-base` and drop the two dind-undoing
+   `RUN` lines.
+
+Steps 1 to 4 are useful on their own: they remove the last `Open3` subprocess
+spawn from a request path. Step 5 is what turns that into a smaller image and a
+smaller Snyk surface.

--- a/docs/pre-started-container-pool.md
+++ b/docs/pre-started-container-pool.md
@@ -1,0 +1,174 @@
+# A pool of pre-started containers
+
+The plan for taking container creation off a test-run, which
+profiling/where-the-traffic-light-time-goes.txt measures and argues for. Read
+that first: this file says only what has to be built, and in what order.
+
+A test-run is what the [test] button in the browser asks for: one run of the
+kata's cyber-dojo.sh in a container, answered with a traffic light.
+
+Nothing is recycled. A spare has only ever run sleep, serves exactly one exec,
+and is then discarded: one test-run, one container, nothing reused and nothing
+to reset. The pool pre-pays create and start; it does not hand a used container
+to the next test-run.
+
+A miss falls back to the path runner.rb takes today, so correctness never
+depends on the pool. That is what makes the whole thing shippable behind a low
+cap, before the aws-prod cluster gains any memory: the cap trades away speed,
+never behaviour.
+
+## 0. A test-run that execs into a container behaves like one that creates its own
+
+The test-run moves from "create a container around this run" to "exec into a
+container that already exists", so everything the run relies on has to survive
+that move. This is what decides whether the rest is buildable at all, so it
+comes first.
+
+profiling/compare_exec_vs_run_container_properties.rb answers it, running the
+same command both ways under the production config with the same id, so that
+any line differing is a real divergence. It reports none. Every property the
+contracts in test/client/container_properties_test.rb pin arrives the same
+either way: all of ulimit -a including data, core, nproc and file locks
+(3A8D99), HOME and the CYBER_DOJO_* vars (3A8D98), /proc/1, /etc/passwd, uid,
+gid, and the sandbox's ownership and writability (3A8D97).
+
+So an exec'd process does inherit what HostConfig.Ulimits sets, and the ulimits
+do not have to be re-applied as `ulimit` builtins inside the exec'd command.
+
+Exec honours Env, which is how the vars belonging to one test-run reach a
+container created before they were known. CYBER_DOJO_ID is for tracing rather
+than for the kata to act on, so it never constrained the design, but it does
+not have to be given up either.
+
+## 1. Split CyberDojoShContainerConfig
+
+Into a per-image half (Image, User, HostConfig, CYBER_DOJO_IMAGE_NAME,
+CYBER_DOJO_SANDBOX) and a per-test-run half (CYBER_DOJO_ID, and the stdio
+group, which a spare does not want). A spare is the per-image half with a sleep
+Cmd, stdin off, and a label marking it a runner spare and naming its image.
+
+## 2. An exec'd test-run beside DaemonRun
+
+Exec create, then a hijacked POST /exec/{id}/start.
+profiling/time_test_run_via_daemon_api_vs_cli.rb is a working sketch of both.
+DockerAttachFrames and DeadlineReader carry over untouched, because the frames
+and the deadline are the same either way.
+
+UnixSocketHttp#attach does not, though. It sends Content-Length: 0, and
+exec-start carries a body saying Detach and Tty, so it needs a hijack that can
+take one. compare_exec_vs_run_container_properties.rb writes that request
+itself and is the shape to lift.
+
+## 3. The timeout path
+
+DaemonRun#stop leans on AutoRemove disposing of the container once it stops. A
+pooled container needs its exec killed, and is then discarded rather than
+returned, because what a timed-out kata left running is not something the next
+test-run should inherit.
+
+## 4. ContainerPool, per worker, shaped like Puller
+
+In-process on Context and mutex-guarded, the way Puller holds @pulled.
+
+It differs from Puller in what a restart costs. The daemon's image store is the
+ground truth behind @pulled, so losing it costs one redundant pull the daemon
+answers at once. Losing the pool's state leaks running containers instead, so
+the daemon has to be the ground truth here too: spares are labelled at create
+time, and a worker discovers and reaps them through
+GET /containers/json?filters=label=... rather than trusting its own memory.
+
+That label query is for reaping, not for claiming, and the difference is the
+whole reason the pool is per worker rather than shared across them. Reaping is
+background work. Claiming is on the test-run, which an API-driven pool answers
+in 14.2ms against 114.1ms today, so a daemon round trip spends against a 14ms
+budget and not a 114ms one. Forked workers share no memory, so a shared pool
+could only be claimed from through the daemon, and the claim would have to be
+atomic (a rename that fails when another worker got there first) rather than a
+list.
+
+Which is to say the two designs differ only in when a worker claims. Claim
+ahead of the test-run and the result is a per-worker pool by definition. Claim
+during it and the learner pays the round trip. A shared pool is therefore not a
+simpler pool, it is this pool with the claim moved onto the path the whole
+exercise exists to shorten, so it is ruled out.
+
+The thread that reaps a used container creates its successor in the same
+breath, so each test-run refills the pool it drained. Container names stay
+unique per forked worker.
+
+## 5. A cap divided by Etc.nprocessors
+
+puma forks a worker per processor, and each worker would hold its own pool, so
+a per-worker cap of ten on a four-core node is forty spares and not ten. The
+number that is configured is therefore the node's, and each worker takes a
+share of it.
+
+An idle container costs the machine about 12MB, so ten spares is about 120MB.
+That is what a low cap buys and what it costs.
+
+## 6. Wire it into runner.rb and pull_image
+
+In runner.rb, take a spare for the image; if there is none, do the test-run
+exactly as today.
+
+Step 4 only refills a pool that a test-run has already drained, so on its own
+the first test-run for an image misses every time. pull_image is what seeds it.
+Creator calls POST /pull_image(id, image_name) when a kata is created,
+which is the earliest moment the runner learns an image is about to be wanted,
+and is already the hook for exactly this kind of preparation. Once the pull
+finishes, create a spare for that image.
+
+The id that pull_image carries is not the key, and does not become one. Puller
+keys @pulled and @pulling on image_name and underscores the id it is passed;
+the pool keys on image_name for the same reason. Nothing is recycled, so there
+is no per-kata state for a spare to hold, and two katas on the same language
+share both the pull and the pool.
+
+Seeding puts a second caller of /containers/create in a background thread, and
+that create can 404 for an image Puller wrongly believes is present. See
+docs/a-missing-image-recovers-only-through-puller.md: the pool should treat
+that 404 the way the run path will, as proof the image has gone, rather than
+retrying quietly for ever.
+
+Seeding is best-effort, not a guarantee. puma forks a worker per processor and
+each worker holds its own pool, so the pull_image request warms only the pool
+of the worker that serves it. A test-run landing on a different worker still
+misses, falls back, and that worker then warms itself through step 4's refill.
+The seed removes the first miss on one worker rather than on all of them.
+
+## 7. A spare's lifetime is its sleep
+
+AutoRemove reaps a spare whose sleep has ended, which bounds a leak without any
+bookkeeping to get wrong. The duration is chosen against the refill rate.
+
+That duration also decides how long a spare pins its image. A spare is a
+container referencing an image, and docker will not remove an image that has
+containers, so an image with spares cannot be reclaimed: not by the rules in
+docs/purge-stale-images.txt, and not by kubelet image garbage collection.
+
+Which is worth having. docs/a-missing-image-recovers-only-through-puller.md
+describes the one unrecoverable state the runner has, an image that Puller's
+add-only @pulled believes is present after it has left the node. Pinning makes
+that state unreachable for any image the pool is keeping warm, and the images
+at risk of reclamation are the cold ones, which by definition have no spares.
+So the pool narrows that window rather than widening it. It does not close it,
+and the 404 from create is still where recovery has to live.
+
+The cost is the other side of the same fact: a purge cannot reclaim an image
+the moment it decides to. It has to wait out the sleep of the last spare, once
+no test-run is refilling them. That is a delay rather than a deadlock, and
+choosing the sleep duration is choosing how long a purge waits.
+
+Not verified here: that docker refuses to remove an image referenced by a
+running container. It is the documented behaviour, and checking it means
+creating containers, so it belongs with the probes rather than in this file.
+
+## 8. Tests, then measure
+
+Re-run profiling/measure_idle_warm_container_cost.sh to confirm what the chosen
+cap really costs on the node it will run on.
+
+## Order
+
+With 0 answered, the risk that is left sits in 1 to 3, which is where the
+test-run changes shape. Steps 4 to 8 are mechanical.

--- a/docs/profiling/check_tty_corrupts_binary_payload.rb
+++ b/docs/profiling/check_tty_corrupts_binary_payload.rb
@@ -12,7 +12,7 @@
 #
 #   newlines   printf of three newline-separated letters, so the translation
 #              can be seen byte for byte
-#   payload    a gzip stream, which is what a press actually returns, checked
+#   payload    a gzip stream, which is what a test-run actually returns, checked
 #              by inflating it the way the runner does
 #
 # Run on the host:

--- a/docs/profiling/compare_exec_vs_run_container_properties.rb
+++ b/docs/profiling/compare_exec_vs_run_container_properties.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+# Compares the container properties a test-run sees when it is exec'd into an
+# already-started container against the properties it sees today, when a
+# container is created around it. A test-run is one run of a kata's
+# cyber-dojo.sh, which is what the browser's [test] button asks for.
+#
+# A pool of pre-started containers moves a test-run from create-and-run to
+# exec, and an exec'd process is not the container's own process. Anything the daemon
+# applies to that first process rather than to the container may not reach an
+# exec. Ulimits are the doubt: cyber_dojo_sh_host_config.rb sends them in
+# HostConfig, and test/client/container_properties_test.rb 3A8D99 pins what a
+# kata sees. HOME and the CYBER_DOJO_* vars are the same class of question, and
+# 3A8D98 pins those. This probe answers all of them at once.
+#
+# It also answers whether the daemon honours Env on exec, since the exec side
+# passes the CYBER_DOJO_* vars that way and an ignored Env shows up as empty
+# values in the diff.
+#
+# Both sides run the same command, under the same production config, with the
+# same id, so every line that differs is a real divergence and nothing else.
+#
+# What it does not cover is the payload path, stdin in and frames out, which
+# time_test_run_via_daemon_api_vs_cli.rb already exercises over an exec. The run
+# side still opens stdin and closes it, because that is the shape production
+# uses and a run given no stdin at all behaves differently.
+#
+# Run on the host:
+#
+#   ruby docs/profiling/compare_exec_vs_run_container_properties.rb
+#
+# Exits non-zero when the two disagree, so a clean exit is the answer step 0 of
+# docs/pre-started-container-pool.md is waiting for.
+
+require 'json'
+require 'socket'
+require_relative '../../source/server/cyber_dojo_sh_container_config'
+require_relative '../../source/server/docker_attach_frames'
+require_relative '../../source/server/externals/unix_socket_http'
+require_relative '../../source/server/sandbox'
+
+IMAGE = ARGV[0] || 'ghcr.io/cyber-dojo-languages/perl_test_simple:dc0f44a'
+SOCKET_PATH = '/var/run/docker.sock'
+ID = '9U3Kry'
+
+# What both sides print. Every line is a property some test pins, or a property
+# a kata would notice losing. ulimit -a arrives whole rather than limit by
+# limit, so that no limit is missed by being forgotten here.
+#
+# The parts are joined into one line, the way container_properties_test.rb
+# joins its own. Init runs tini as PID 1 and tini's argv carries the command it
+# wraps, so a newline in the command becomes a line of /proc/1/cmdline, which
+# the probe reads back a few parts later.
+PROBE_PARTS = [
+  'echo "home=${HOME}"',
+  'echo "image_name=${CYBER_DOJO_IMAGE_NAME}"',
+  'echo "id=${CYBER_DOJO_ID}"',
+  'echo "sandbox=${CYBER_DOJO_SANDBOX}"',
+  'echo "uid=$(id -u)"',
+  'echo "gid=$(id -g)"',
+  'echo "groups=$(id -G)"',
+  'echo "proc1=$(cut -c1-9 /proc/1/cmdline)"',
+  'echo "passwd=$(getent passwd $(id -u))"',
+  "echo \"sandbox_stat=$(stat --printf='%u:%g:%A' #{Sandbox::DIR})\"",
+  "echo \"tmp_stat=$(stat --printf='%u:%g:%A' /tmp)\"",
+  "echo \"sandbox_write=$(touch #{Sandbox::DIR}/probe 2>/dev/null && echo yes || echo no)\"",
+  "ulimit -a | sed 's/^/ulimit /'"
+].freeze
+
+PROBE_BODY = PROBE_PARTS.join('; ')
+
+# The daemon, spoken to the way the runner speaks to it.
+def client
+  @client ||= UnixSocketHttp.new(SOCKET_PATH)
+end
+
+# Answers the new container's id. A refusal is raised rather than carried on
+# with, since every later call needs that id.
+def create(name, body)
+  code, response = client.request('POST', "/containers/create?name=#{name}", body)
+  raise "create answered #{code}: #{response}" unless code.between?(200, 299)
+
+  JSON.parse(response)['Id']
+end
+
+# Runs the container's own command.
+def start(container_id)
+  code, response = client.request('POST', "/containers/#{container_id}/start")
+  raise "start answered #{code}: #{response}" unless code.between?(200, 299)
+end
+
+# The production config, with the probe in place of the kata's own command and
+# nothing else touched. The stdio group is left alone in particular: a run that
+# is given no stdin at all is not the run production does, and what it hands a
+# command that reads one is not the same either.
+def probe_config(cmd)
+  CyberDojoShContainerConfig.create_config(ID, IMAGE).merge('Cmd' => ['bash', '-c', cmd])
+end
+
+# The properties as a test-run sees them today: a container created around the
+# command, attached to before it starts so that no output is missed.
+def properties_via_run
+  container_id = create("probe_run_#{Process.pid}", probe_config(PROBE_BODY))
+  stream = client.attach("/containers/#{container_id}/attach?stream=1&stdin=1&stdout=1&stderr=1")
+  start(container_id)
+  # The payload a test-run would send is empty here, but the half-close still has
+  # to happen: it is what gives stdin an end, and a command reading one waits
+  # for ever without it.
+  stream.close_write
+  stdout, = DockerAttachFrames.demultiplex(stream)
+  stream.close
+  stdout
+end
+
+# The properties as a test-run would see them from a pool: a container already
+# sleeping, exec'd into. The vars a test-run carries are passed on the exec, which
+# is where they would have to live once create no longer knows them.
+def properties_via_exec
+  container_id = create("probe_exec_#{Process.pid}", probe_config('sleep 60'))
+  start(container_id)
+  stdout = exec_probe(container_id)
+  stop(container_id)
+  stdout
+end
+
+# Answers what the probe printed inside the already-running container.
+def exec_probe(container_id)
+  exec_id = exec_create(container_id)
+  stream = exec_start(exec_id)
+  stdout, = DockerAttachFrames.demultiplex(stream)
+  stream.close
+  stdout
+end
+
+# Answers the new exec's id. The user and the vars are set here because a
+# pooled container was created before either was known.
+def exec_create(container_id)
+  code, response = client.request('POST', "/containers/#{container_id}/exec", {
+                                    'AttachStdin' => false,
+                                    'AttachStdout' => true,
+                                    'AttachStderr' => true,
+                                    'Tty' => false,
+                                    'User' => "#{Sandbox::UID}:#{Sandbox::GID}",
+                                    'Env' => [
+                                      "CYBER_DOJO_IMAGE_NAME=#{IMAGE}",
+                                      "CYBER_DOJO_ID=#{ID}",
+                                      "CYBER_DOJO_SANDBOX=#{Sandbox::DIR}"
+                                    ],
+                                    'Cmd' => ['bash', '-c', PROBE_BODY]
+                                  })
+  raise "exec create answered #{code}: #{response}" unless code.between?(200, 299)
+
+  JSON.parse(response)['Id']
+end
+
+# Starting an exec hijacks the connection the way attach does, but it carries a
+# body where attach carries none, so the request is written here rather than
+# through UnixSocketHttp#attach.
+def exec_start(exec_id)
+  socket = UNIXSocket.new(SOCKET_PATH)
+  body = JSON.generate({ 'Detach' => false, 'Tty' => false })
+  socket.write(
+    "POST /exec/#{exec_id}/start HTTP/1.1\r\nHost: docker\r\n" \
+    "Content-Type: application/json\r\nContent-Length: #{body.bytesize}\r\n" \
+    "Upgrade: tcp\r\nConnection: Upgrade\r\n\r\n#{body}"
+  )
+  socket.gets
+  while (line = socket.gets)
+    break if ["\r\n", "\n"].include?(line)
+  end
+  socket.binmode
+  socket
+end
+
+# A sleeping container outlives the probe unless it is stopped, and AutoRemove
+# disposes of it once it is.
+def stop(container_id)
+  client.request('POST', "/containers/#{container_id}/stop?t=1")
+end
+
+# Every property, side by side, with the ones that disagree named. A difference
+# is not a failure of the probe: it is the answer, and it says what a pool has
+# to carry onto the exec itself.
+def report(run, exec)
+  run_properties = keyed(run)
+  exec_properties = keyed(exec)
+  names = run_properties.keys | exec_properties.keys
+  differences = names.reject { |name| run_properties[name] == exec_properties[name] }
+
+  puts(format('%-38s %-20s %-20s', 'property', 'run', 'exec'))
+  names.each do |name|
+    differs = differences.include?(name) ? ' <-- differs' : ''
+    puts(format('%-38s %-20s %-20s%s', name, run_properties[name], exec_properties[name], differs))
+  end
+  differences
+end
+
+# Each printed line as name and value, so that the two sides line up by name
+# rather than by position. An echo'd line separates the two with its =, and a
+# ulimit -a line ends with its value, having spent everything before it naming
+# the limit.
+def keyed(stdout)
+  stdout.split("\n").each_with_object({}) do |line, memo|
+    if line.start_with?('ulimit ')
+      name, _sep, value = line.rpartition(/\s+/)
+      memo[name.strip] = value.strip
+    else
+      name, _sep, value = line.partition('=')
+      memo[name.strip] = value.strip
+    end
+  end
+end
+
+run_stdout = properties_via_run
+exec_stdout = properties_via_exec
+differences = report(run_stdout, exec_stdout)
+puts
+if differences.empty?
+  puts('Same properties either way. An exec\'d test-run is indistinguishable.')
+else
+  puts("Differ: #{differences.join(', ')}")
+  # What each side actually sent, so that a difference can be read rather than
+  # inferred from a name the parsing chose.
+  puts("\n--- run stdout ---\n#{run_stdout}")
+  puts("\n--- exec stdout ---\n#{exec_stdout}")
+end
+exit(differences.empty? ? 0 : 1)

--- a/docs/profiling/measure_idle_warm_container_cost.sh
+++ b/docs/profiling/measure_idle_warm_container_cost.sh
@@ -14,7 +14,7 @@ set -Eeu -o pipefail
 #   o) memory the whole machine has lost, which includes the daemon's own
 #      bookkeeping and not merely the containers' processes
 #   o) what docker itself reports for one container
-#   o) how long a press takes, since a daemon tracking hundreds of containers
+#   o) how long a test-run takes, since a daemon tracking hundreds of containers
 #      may answer more slowly even when memory is fine
 #
 # Memory is read from inside a container because containers share the kernel
@@ -28,7 +28,7 @@ probe_help_check "${1:-}" \
 "Usage: docs/profiling/measure_idle_warm_container_cost.sh [-h] [IMAGE]
 
 Starts idle containers in batches and reports memory lost, per-container usage
-and press latency at each batch size. Removes every container it started.
+and test-run latency at each batch size. Removes every container it started.
 
 Options:
   -h    Show this help
@@ -39,7 +39,7 @@ Example:
 readonly IMAGE="${1:-ghcr.io/cyber-dojo-languages/perl_test_simple:dc0f44a}"
 readonly NAME_PREFIX="probe_idle_$$"
 readonly LEVELS='10 25 50'
-readonly PRESS_RUNS=5
+readonly TEST_RUN_SAMPLES=5
 
 readonly UID_SANDBOX=41966
 readonly GID_SANDBOX=51966
@@ -75,17 +75,17 @@ available_kb()
     awk '/MemAvailable/ { print $2 }' /proc/meminfo
 }
 
-# Prints the mean milliseconds of a press that creates its own container, which
-# is what a pool miss costs and what a busy daemon would slow down.
-press_ms()
+# Prints the mean milliseconds of a test-run that creates its own container,
+# which is what a pool miss costs and what a busy daemon would slow down.
+test_run_ms()
 {
   local i
   local -r t0=${EPOCHREALTIME/./}
-  for (( i = 0; i < PRESS_RUNS; i++ )); do
+  for (( i = 0; i < TEST_RUN_SAMPLES; i++ )); do
     docker run --rm --entrypoint='' "${IMAGE}" true > /dev/null 2>&1
   done
   local -r t1=${EPOCHREALTIME/./}
-  echo $(( (t1 - t0) / PRESS_RUNS / 1000 ))
+  echo $(( (t1 - t0) / TEST_RUN_SAMPLES / 1000 ))
 }
 
 # Starts count idle containers, numbered from the current total.
@@ -105,10 +105,10 @@ echo "image: ${IMAGE}"
 echo
 
 readonly BASE_KB="$(available_kb)"
-readonly BASE_PRESS="$(press_ms)"
+readonly BASE_TEST_RUN="$(test_run_ms)"
 
-printf '%8s %14s %14s %12s %10s\n' idle 'avail KB' 'lost KB' 'KB each' 'press ms'
-printf '%8s %14s %14s %12s %10s\n' 0 "${BASE_KB}" 0 0 "${BASE_PRESS}"
+printf '%8s %14s %14s %12s %11s\n' idle 'avail KB' 'lost KB' 'KB each' 'test-run ms'
+printf '%8s %14s %14s %12s %11s\n' 0 "${BASE_KB}" 0 0 "${BASE_TEST_RUN}"
 
 started=0
 for level in ${LEVELS}; do
@@ -117,8 +117,8 @@ for level in ${LEVELS}; do
 
   avail_kb="$(available_kb)"
   lost_kb=$(( BASE_KB - avail_kb ))
-  printf '%8s %14s %14s %12s %10s\n' \
-    "${started}" "${avail_kb}" "${lost_kb}" "$(( lost_kb / started ))" "$(press_ms)"
+  printf '%8s %14s %14s %12s %11s\n' \
+    "${started}" "${avail_kb}" "${lost_kb}" "$(( lost_kb / started ))" "$(test_run_ms)"
 done
 
 echo

--- a/docs/profiling/probe_lib.sh
+++ b/docs/profiling/probe_lib.sh
@@ -69,7 +69,7 @@ probe_timeit_ms()
 
 # Describe where the probe is running, so results from different architectures
 # are not accidentally compared. Emulation of the runner image on an arm64 host
-# inflated an earlier round of these measurements by about 72ms per press.
+# inflated an earlier round of these measurements by about 72ms per test-run.
 probe_environment()
 {
   # -m rather than --machine: these probes run on the host as well as inside

--- a/docs/profiling/time_docker_run_phases.sh
+++ b/docs/profiling/time_docker_run_phases.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Decompose the runner's fixed per-press overhead into docker CLI cost and
+# Decompose the runner's fixed per-test-run overhead into docker CLI cost and
 # daemon container-lifecycle cost.
 #
 # Run it twice: on the host, and inside the runner image with the docker socket

--- a/docs/profiling/time_docker_run_split.sh
+++ b/docs/profiling/time_docker_run_split.sh
@@ -2,9 +2,9 @@
 # Split `docker run` into its create, start and remove phases.
 #
 # The question it answers: could the runner keep a pool of pre-created but
-# never-started containers, paying create ahead of the user's press and only
-# start on the critical path? That would preserve the guarantee that every press
-# gets a container nothing else has touched.
+# never-started containers, paying create ahead of the user's test-run and only
+# start on the critical path? That would preserve the guarantee that every
+# test-run gets a container nothing else has touched.
 #
 # The answer is mostly no. It found create at about 16ms of daemon work against
 # start at about 48ms, so pre-creating recovers only the smaller half. It also

--- a/docs/profiling/time_docker_stop_alone_to_cli_exit.rb
+++ b/docs/profiling/time_docker_stop_alone_to_cli_exit.rb
@@ -2,12 +2,12 @@
 
 # Measures how soon [docker run] exits once [docker stop] has been issued.
 #
-# capture3_with_timeout.rb ends a timed-out press by stopping the container and
+# capture3_with_timeout.rb ends a timed-out test-run by stopping the container and
 # nothing else: the container's stdout closes, so the CLI exits and the
 # runner's read completes. This probe is what that rests on, and it also prices
 # the alternative of signalling the CLI first.
 #
-# Two ways of ending a timed-out press:
+# Two ways of ending a timed-out test-run:
 #
 #   stop only  no signals at all: docker stop --time 1, then wait for the CLI
 #   kill+stop  TERM then KILL to the CLI's process group, and a docker stop
@@ -22,7 +22,7 @@
 #              end and send_tgz cannot fork the find, file, tar and gzip its
 #              EXIT trap needs
 #
-# The press is the real one: the payload carries cyber_dojo_main.sh from
+# The test-run is the real one: the payload carries cyber_dojo_main.sh from
 # home_files.rb next to the kata, and the container runs it, so the EXIT trap
 # and the pids-limit interact as they do in production. A cyber-dojo.sh that
 # merely backgrounds work is not enough on its own; that returns at once and
@@ -102,10 +102,10 @@ def docker_run_command(name)
   ].join(' ')
 end
 
-# Starts the press and returns the pieces needed to wait it out: the waiter
+# Starts the test-run and returns the pieces needed to wait it out: the waiter
 # thread for the CLI process, its pid, a thread reading stdout to EOF, the read
-# end of that pipe, and the monotonic instant the press began.
-def start_press(name, kata, pgroup:)
+# end of that pipe, and the monotonic instant the test-run began.
+def start_test_run(name, kata, pgroup:)
   in_read, in_write = IO.pipe
   out_read, out_write = IO.pipe
   in_write.binmode
@@ -131,12 +131,12 @@ def docker_stop(name)
   now - t0
 end
 
-# Times a timed-out press ended by docker stop alone, with no signals sent to
+# Times a timed-out test-run ended by docker stop alone, with no signals sent to
 # the CLI at all. The stop runs on a thread so that the interval being measured
 # is the CLI's exit against the instant the stop was issued, rather than against
 # the stop returning.
 def timeout_via_stop_only(name, kata)
-  waiter, _pid, reader, out_read, t0 = start_press(name, kata, pgroup: false)
+  waiter, _pid, reader, out_read, t0 = start_test_run(name, kata, pgroup: false)
 
   waiter.join(MAX_SECONDS)
   t_stop = now
@@ -153,11 +153,11 @@ def timeout_via_stop_only(name, kata)
     bytes: stdout.to_s.bytesize, name: name }
 end
 
-# Times a timed-out press ended by signalling the CLI first: Timeout.timeout
+# Times a timed-out test-run ended by signalling the CLI first: Timeout.timeout
 # around the wait, TERM to the process group, KILL if the join fails, and a
 # docker stop besides, because killing the CLI leaves the container running.
 def timeout_via_kill_and_stop(name, kata)
-  waiter, pid, reader, out_read, t0 = start_press(name, kata, pgroup: true)
+  waiter, pid, reader, out_read, t0 = start_test_run(name, kata, pgroup: true)
 
   begin
     Timeout.timeout(MAX_SECONDS) { waiter.value }
@@ -225,7 +225,7 @@ end
 puts "image: #{IMAGE}"
 puts "max_seconds: #{MAX_SECONDS}"
 puts(format('%-32s %9s %13s %13s %9s %10s',
-            'timed-out press', 'total ms', 'overshoot ms', 'stop to exit', 'stop ms', 'payload B'))
+            'timed-out test-run', 'total ms', 'overshoot ms', 'stop to exit', 'stop ms', 'payload B'))
 rows.each { |label, results| print_row(label, results) }
 
 left = survivors(names)

--- a/docs/profiling/time_oci_runtimes.sh
+++ b/docs/profiling/time_oci_runtimes.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Compare crun against runc on the same OCI bundle, to price the OCI runtime's
-# share of the runner's per-press container-lifecycle cost.
+# share of the runner's per-test-run container-lifecycle cost.
 #
 # It found runc at 6226us and crun at 2532us for the whole lifecycle. crun is
 # 2.5x faster, but that is only 3.7ms off a 92ms lifecycle, about 4%, so the OCI

--- a/docs/profiling/time_test_run_via_daemon_api_vs_cli.rb
+++ b/docs/profiling/time_test_run_via_daemon_api_vs_cli.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
-# Measures a press driven straight against the docker daemon, against the same
-# press driven through the docker CLI.
+# Measures a test-run driven straight against the docker daemon, against the
+# same test-run driven through the docker CLI. A test-run is one run of a
+# kata's cyber-dojo.sh, which is what the browser's [test] button asks for.
 #
-# Every press currently spawns the CLI, which does HTTP against
+# Every test-run currently spawns the CLI, which does HTTP against
 # /var/run/docker.sock on the runner's behalf: create, attach, start, proxy the
 # streams, and with --rm wait for the removal before exiting. The runner waits
 # on that process, so it inherits all of it. Doing the same calls directly
@@ -16,7 +17,7 @@
 #
 # Run on the host:
 #
-#   ruby docs/profiling/time_press_via_daemon_api_vs_cli.rb
+#   ruby docs/profiling/time_test_run_via_daemon_api_vs_cli.rb
 #
 # Not inside the runner image on a developer machine whose architecture differs
 # from it. What is being compared is largely the cost of the docker CLI's own
@@ -34,11 +35,11 @@ SOCKET_PATH = '/var/run/docker.sock'
 UID = 41_966
 GID = 51_966
 
-# What the container does with the press: take the files on stdin and send a
+# What the container does with the test-run: take the files on stdin and send a
 # payload back, which is the shape of cyber_dojo_main.sh without the kata.
 BODY = 'tar -C /tmp -zxf - && dd if=/dev/zero bs=1024 count=64 status=none | gzip -1'
 
-# The files a press delivers, sized like a small kata's.
+# The files a test-run delivers, sized like a small kata's.
 PAYLOAD_IN = TGZ.of({
                       'tmp/hiker.pl' => "sub answer {\n  return 6 * 9;\n}\n\n1;\n",
                       'tmp/hiker.t' => "use Test::Simple tests => 1;\nok(answer() == 42);\n",
@@ -158,8 +159,8 @@ def read_frames(socket)
   stdout
 end
 
-# Times one press driven straight against the daemon.
-def press_via_api(name)
+# Times one test-run driven straight against the daemon.
+def test_run_via_api(name)
   t0 = now
   code, body = request('POST', "/containers/create?name=#{name}", create_body(BODY))
   raise "create failed: #{code} #{body}" unless [200, 201].include?(code)
@@ -171,7 +172,7 @@ def press_via_api(name)
 
   stream.write(PAYLOAD_IN)
   # Half-close, so the container's [tar -zxf -] sees EOF on stdin. Without it
-  # tar waits for more input and the press never completes.
+  # tar waits for more input and the test-run never completes.
   stream.close_write
   read_frames(stream)
   stream.close
@@ -180,7 +181,7 @@ end
 
 # Starts a container that sits idle, which is what a pool holds ready. Returns
 # its id, and the seconds it took, since that is the work the refill thread
-# does after a press rather than during one.
+# does after a test-run rather than during one.
 def start_idle_container(name)
   t0 = now
   body = create_body('sleep 300')
@@ -197,10 +198,10 @@ def start_idle_container(name)
   [id, now - t0]
 end
 
-# Times a press into a pooled container, over the socket. An exec is created
+# Times a test-run into a pooled container, over the socket. An exec is created
 # and then started, and starting it hijacks the connection the same way attach
 # does, so the payload and the frames travel over that one socket.
-def press_via_api_pool(id)
+def test_run_via_api_pool(id)
   t0 = now
   code, response = request('POST', "/containers/#{id}/exec", {
                              'AttachStdin' => true,
@@ -230,9 +231,9 @@ def press_via_api_pool(id)
   now - t0
 end
 
-# Times a press driven by spawning a docker CLI command, writing the payload to
-# its stdin and reading its stdout, the way capture3_with_timeout.rb does.
-def spawned_press(command)
+# Times a test-run driven by spawning a docker CLI command, writing the payload
+# to its stdin and reading its stdout, the way capture3_with_timeout.rb does.
+def spawned_test_run(command)
   in_read, in_write = IO.pipe
   out_read, out_write = IO.pipe
   in_write.binmode
@@ -253,9 +254,9 @@ def spawned_press(command)
   seconds
 end
 
-# Times the press driven through the CLI, as runner.rb does it now.
-def press_via_cli(name)
-  spawned_press([
+# Times the test-run driven through the CLI, as runner.rb does it now.
+def test_run_via_cli(name)
+  spawned_test_run([
     'docker run --rm --init --interactive',
     "--user=#{UID}:#{GID}",
     "--tmpfs /sandbox:exec,size=250M,uid=#{UID},gid=#{GID}",
@@ -268,11 +269,11 @@ def press_via_cli(name)
   ].join(' '))
 end
 
-# Times a press into a container the CLI started earlier and which has only
+# Times a test-run into a container the CLI started earlier and which has only
 # ever run sleep, which is the best a pool built on the CLI can do. Included
 # here so it is measured in the same run as the other two rather than compared
 # across probes and machines.
-def press_via_cli_prestarted(name)
+def test_run_via_cli_prestarted(name)
   prepare = [
     'docker run --detach --init --interactive',
     "--user=#{UID}:#{GID}",
@@ -286,7 +287,7 @@ def press_via_cli_prestarted(name)
   ].join(' ')
   system(prepare, out: File::NULL, err: File::NULL)
 
-  seconds = spawned_press(%(docker exec --interactive #{name} bash -c "#{BODY}"))
+  seconds = spawned_test_run(%(docker exec --interactive #{name} bash -c "#{BODY}"))
   system("docker rm --force #{name}", out: File::NULL, err: File::NULL)
   seconds
 end
@@ -303,23 +304,23 @@ api_pool = []
 refill = []
 
 RUNS.times do |i|
-  api << press_via_api("probe_api_#{i}_#{Process.pid}")
-  cli << press_via_cli("probe_cli_#{i}_#{Process.pid}")
-  cli_prestarted << press_via_cli_prestarted("probe_warm_#{i}_#{Process.pid}")
+  api << test_run_via_api("probe_api_#{i}_#{Process.pid}")
+  cli << test_run_via_cli("probe_cli_#{i}_#{Process.pid}")
+  cli_prestarted << test_run_via_cli_prestarted("probe_warm_#{i}_#{Process.pid}")
 
   # Prepared before the clock starts, exactly as a pool prepares it before the
-  # learner presses anything.
+  # learner asks for a test-run.
   id, seconds = start_idle_container("probe_apipool_#{i}_#{Process.pid}")
   refill << seconds
-  api_pool << press_via_api_pool(id)
+  api_pool << test_run_via_api_pool(id)
   request('POST', "/containers/#{id}/kill")
 end
 
 puts "image: #{IMAGE}"
-puts(format('%-40s %10s', 'press', 'ms'))
+puts(format('%-40s %10s', 'test-run', 'ms'))
 puts(format('%-40s %10s', 'via docker CLI (docker run --rm)', mean_millis(cli)))
 puts(format('%-40s %10s', 'via docker CLI, pre-started (exec)', mean_millis(cli_prestarted)))
 puts(format('%-40s %10s', 'via daemon API (AutoRemove, no wait)', mean_millis(api)))
 puts(format('%-40s %10s', 'via daemon API, pre-started (exec)', mean_millis(api_pool)))
 puts
-puts(format('%-40s %10s', 'off the press: preparing a spare', mean_millis(refill)))
+puts(format('%-40s %10s', 'off the test-run: preparing a spare', mean_millis(refill)))

--- a/docs/profiling/time_test_run_with_cold_created_started_container.rb
+++ b/docs/profiling/time_test_run_with_cold_created_started_container.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-# Measures how much of a container's startup a pool could take off the press.
+# Measures how much of a container's startup a pool could take off a test-run.
+# A test-run is one run of a kata's cyber-dojo.sh, which is what the browser's
+# [test] button asks for.
 #
 # time_docker_run_split.sh splits docker run into create at about 16ms and
 # start at about 48ms, which says a pool of pre-created but never-started
@@ -8,24 +10,24 @@
 # pre-started containers recovers, because a started container's stdin is
 # already closed and the payload has to arrive another way.
 #
-# So three variants are timed, each from the instant of the press to the
+# So three variants are timed, each from the instant the test-run starts to the
 # instant the whole payload has been read back, which is what the learner
 # waits for:
 #
 #   cold    docker run, as runner.rb does it now
-#   created docker create off the clock, press is docker start --attach
-#   started container already running and idle, press is docker exec -i
+#   created docker create off the clock, the run is docker start --attach
+#   started container already running and idle, the run is docker exec -i
 #
 # The work inside is identical and trivial in all three, so the differences
 # are container lifecycle rather than the kata.
 #
 # Run on the host:
 #
-#   ruby docs/profiling/time_press_with_cold_created_started_container.rb
+#   ruby docs/profiling/time_test_run_with_cold_created_started_container.rb
 #
 # Not inside the runner image on a developer machine whose architecture differs
 # from it. Each variant spawns a docker CLI, and emulating that process inflates
-# every row: the pre-started press reads 114.3ms emulated against 32.2ms here.
+# every row: the pre-started row reads 114.3ms emulated against 32.2ms here.
 
 require_relative '../../source/server/tgz'
 
@@ -49,11 +51,11 @@ FLAGS = [
   '--memory=2g --net=none --pids-limit=128 --security-opt=no-new-privileges'
 ].join(' ')
 
-# What the container does with the press: take the files on stdin and send a
+# What the container does with the test-run: take the files on stdin and send a
 # payload back, which is the shape of cyber_dojo_main.sh without the kata.
 BODY = 'tar -C /tmp -zxf - && dd if=/dev/zero bs=1024 count=64 status=none | gzip -1'
 
-# The files a press delivers, sized like a small kata's.
+# The files a test-run delivers, sized like a small kata's.
 PAYLOAD_IN = TGZ.of({
                       'tmp/hiker.pl' => "sub answer {\n  return 6 * 9;\n}\n\n1;\n",
                       'tmp/hiker.t' => "use Test::Simple tests => 1;\nok(answer() == 42);\n",
@@ -65,10 +67,10 @@ def now
   Process.clock_gettime(Process::CLOCK_MONOTONIC)
 end
 
-# Runs a command, writes the press payload to its stdin, reads its stdout to
-# EOF, and returns the seconds that took. This is what capture3_with_timeout.rb
-# does, reduced to what is being compared.
-def press(command)
+# Runs a command, writes the test-run's payload to its stdin, reads its stdout
+# to EOF, and returns the seconds that took. This is what
+# capture3_with_timeout.rb does, reduced to what is being compared.
+def test_run(command)
   in_read, in_write = IO.pipe
   out_read, out_write = IO.pipe
   in_write.binmode
@@ -94,26 +96,26 @@ def quietly(command)
   system(command, out: File::NULL, err: File::NULL)
 end
 
-# Times a press against a container created fresh by the press itself.
+# Times a test-run against a container it creates fresh itself.
 def time_cold(name)
-  seconds = press("docker run #{FLAGS} --name #{name} --entrypoint='' #{IMAGE} bash -c \"#{BODY}\"")
+  seconds = test_run("docker run #{FLAGS} --name #{name} --entrypoint='' #{IMAGE} bash -c \"#{BODY}\"")
   quietly("docker rm --force #{name}")
   seconds
 end
 
-# Times a press against a container created before the clock started.
+# Times a test-run against a container created before the clock started.
 def time_created(name)
   quietly("docker create #{FLAGS} --name #{name} --entrypoint='' #{IMAGE} bash -c \"#{BODY}\"")
-  seconds = press("docker start --attach --interactive #{name}")
+  seconds = test_run("docker start --attach --interactive #{name}")
   quietly("docker rm --force #{name}")
   seconds
 end
 
-# Times a press against a container already running and idle, where the press
+# Times a test-run against a container already running and idle, where the run
 # is a docker exec because a started container's stdin is already closed.
 def time_started(name)
   quietly("docker run --detach #{FLAGS} --name #{name} --entrypoint='' #{IMAGE} sleep 300")
-  seconds = press("docker exec --interactive #{name} bash -c \"#{BODY}\"")
+  seconds = test_run("docker exec --interactive #{name} bash -c \"#{BODY}\"")
   quietly("docker rm --force #{name}")
   seconds
 end
@@ -128,13 +130,13 @@ created = []
 started = []
 
 RUNS.times do |i|
-  cold << time_cold("probe_press_cold_#{i}_#{Process.pid}")
-  created << time_created("probe_press_created_#{i}_#{Process.pid}")
-  started << time_started("probe_press_started_#{i}_#{Process.pid}")
+  cold << time_cold("probe_cold_#{i}_#{Process.pid}")
+  created << time_created("probe_created_#{i}_#{Process.pid}")
+  started << time_started("probe_started_#{i}_#{Process.pid}")
 end
 
 puts "image: #{IMAGE}"
-puts(format('%-40s %10s', 'press', 'ms'))
+puts(format('%-40s %10s', 'test-run', 'ms'))
 puts(format('%-40s %10s', 'cold: docker run', mean_millis(cold)))
 puts(format('%-40s %10s', 'pre-created: docker start --attach', mean_millis(created)))
 puts(format('%-40s %10s', 'pre-started: docker exec -i', mean_millis(started)))

--- a/docs/profiling/time_timeout_path_api_vs_cli.rb
+++ b/docs/profiling/time_timeout_path_api_vs_cli.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Measures what a timed-out press costs beyond max_seconds, and whether the
+# Measures what a timed-out test-run costs beyond max_seconds, and whether the
 # container is actually gone afterwards.
 #
 # A learner whose cyber-dojo.sh loops forever should wait max_seconds and then
@@ -127,7 +127,7 @@ end
 
 # Reads exactly n bytes, or raises DeadlineReached, or returns nil at end of
 # stream. The deadline is absolute and reapplied before every wait, because it
-# bounds the whole press rather than one read: a container dribbling output
+# bounds the whole test-run rather than one read: a container dribbling output
 # would never trip a per-read timeout.
 #
 # Production would write this with IO#timeout=, which ruby 3.4 has and which
@@ -160,7 +160,7 @@ def read_frames_until(socket, deadline)
   end
 end
 
-# Times a timed-out press over the socket. When threaded_stop is true the
+# Times a timed-out test-run over the socket. When threaded_stop is true the
 # answer is given the moment the deadline fires and the container is stopped
 # behind it, which is what a runner would do.
 def timeout_via_api(name, threaded_stop:)
@@ -187,7 +187,8 @@ def timeout_via_api(name, threaded_stop:)
   [seconds, name]
 end
 
-# Times a timed-out press through the CLI, reproducing capture3_with_timeout.rb:
+# Times a timed-out test-run through the CLI, reproducing
+# capture3_with_timeout.rb:
 # Timeout.timeout around the wait, then TERM to the process group, then KILL if
 # the join fails, and a docker stop besides, because killing the CLI leaves the
 # container running.
@@ -272,7 +273,7 @@ end
 
 puts "image: #{IMAGE}"
 puts "max_seconds: #{MAX_SECONDS}"
-puts(format('%-34s %10s %14s', 'timed-out press', 'total ms', 'overshoot ms'))
+puts(format('%-34s %10s %14s', 'timed-out test-run', 'total ms', 'overshoot ms'))
 print_row('cli: Timeout, kill group, stop', cli)
 print_row('api: read deadline, stop inline', api)
 print_row('api: read deadline, stop threaded', api_threaded)

--- a/docs/profiling/where-the-traffic-light-time-goes.txt
+++ b/docs/profiling/where-the-traffic-light-time-goes.txt
@@ -2,9 +2,10 @@ Where the traffic-light time goes
 =================================
 
 A review of the run path in runner.rb, capture3_with_timeout.rb and
-home_files.rb, asking one question: what stands between the learner pressing
-the test button and the traffic-light lighting up, and what does not have to
-be there.
+home_files.rb, asking one question: what stands between the learner clicking
+the browser's [test] button and the traffic-light lighting up, and what does
+not have to be there. One click is one test-run: one run of the kata's
+cyber-dojo.sh in a container.
 
 The measurements come from three probes in this directory:
 
@@ -14,10 +15,10 @@ The measurements come from three probes in this directory:
   check_gzip_level_1_flag_support.sh   whether -1 is portable across images
   time_container_removal_inline_vs_deferred.sh  what --rm costs the learner
   time_stdout_eof_to_cli_exit.rb       whether the payload arrives any earlier
-  time_press_with_cold_created_started_container.rb  what a pool takes off the press
+  time_test_run_with_cold_created_started_container.rb  what a pool takes off a test-run
   measure_idle_warm_container_cost.sh  what an idle pooled container costs
-  time_press_via_daemon_api_vs_cli.rb  what the docker CLI itself costs
-  time_timeout_path_api_vs_cli.rb      what a timed-out press costs each way
+  time_test_run_via_daemon_api_vs_cli.rb  what the docker CLI itself costs
+  time_timeout_path_api_vs_cli.rb      what a timed-out test-run costs each way
   time_docker_stop_alone_to_cli_exit.rb  how soon the CLI exits after the stop
   time_streamed_tar_vs_tar_file.sh     what send_tgz()'s intermediate file costs
 
@@ -183,25 +184,25 @@ it, and the lifecycle is what to attack:
   status need only be consulted when the payload is missing or unusable, or
   when the run timed out.
 
-  Have a container ready before the press. Whatever the pool does, the press
-  should not be paying for a container's lifecycle. How much is recoverable
-  depends on how far ahead the container is prepared, and the two useful
-  points are measurably different.
+  Have a container ready before the test-run. Whatever the pool does, the
+  test-run should not be paying for a container's lifecycle. How much is
+  recoverable depends on how far ahead the container is prepared, and the two
+  useful points are measurably different.
 
   time_docker_run_split.sh puts create at about 16ms of daemon work against
   start at about 48ms, so pre-creating alone leaves the larger half on the
-  press. time_press_with_cold_created_started_container.rb measures the press
-  end to end, from the spawn to the whole payload being read back. Run on the
-  host, unemulated. Its cold row does not pass --rm, because every variant
-  here removes its container as a separate step:
+  test-run. time_test_run_with_cold_created_started_container.rb measures the
+  test-run end to end, from the spawn to the whole payload being read back. Run
+  on the host, unemulated. Its cold row does not pass --rm, because every
+  variant here removes its container as a separate step:
 
-    press                                            ms
+    test-run                                         ms
     cold: docker run                               84.7
     pre-created: docker start --attach             63.2
     pre-started: docker exec -i                    32.2
 
   So a pre-created container saves about 21ms and a pre-started one about
-  52ms. Measured instead against what a press costs today, which does pass
+  52ms. Measured instead against what a test-run costs today, which does pass
   --rm and so costs 116.4ms, they save about 53ms and about 84ms.
 
   The gap between those two baselines, 116.4 against 84.7, is the removal
@@ -212,30 +213,30 @@ it, and the lifecycle is what to attack:
   the floor is not zero.
 
   Both keep the isolation the current design has. A pre-started container has
-  only ever run sleep, serves exactly one exec, and is then removed: one press,
-  one container, nothing reused and nothing to reset. A pool miss falls back to
-  a cold start, so correctness never depends on the pool.
+  only ever run sleep, serves exactly one exec, and is then removed: one
+  test-run, one container, nothing reused and nothing to reset. A pool miss
+  falls back to a cold start, so correctness never depends on the pool.
 
   The pool can also be kept very simple. The thread that reaps a used container
-  can create its successor in the same breath, so each press refills the pool
-  it drained, and the only extra bookkeeping is discarding spares for images
-  that stop being used.
+  can create its successor in the same breath, so each test-run refills the
+  pool it drained, and the only extra bookkeeping is discarding spares for
+  images that stop being used.
 
   Sizing it. The pool is per image, because a node runs many katas in many
   languages at once, so the total is the per-image target multiplied by the
   number of hot images. A per-image target follows from concurrency: if at most
-  N presses for one image overlap, N spares is what a simultaneous burst
+  N test-runs for one image overlap, N spares is what a simultaneous burst
   consumes, and a burst only exhausts a smaller pool if it lands inside the
-  refill window. Misses are free in the sense that they cost what every press
-  costs today.
+  refill window. Misses are free in the sense that they cost what every
+  test-run costs today.
 
   What that total costs, from measure_idle_warm_container_cost.sh:
 
-        idle       avail KB        lost KB      KB each   press ms
-           0        7391924              0            0        140
-          10        7241348         150576        15057        142
-          25        7047140         344784        13791        150
-          50        6802536         589388        11787        161
+        idle       avail KB        lost KB      KB each   test-run ms
+           0        7391924              0            0           140
+          10        7241348         150576        15057           142
+          25        7047140         344784        13791           150
+          50        6802536         589388        11787           161
 
     docker stats for one idle container: 708KiB / 2GiB, 2 PIDs
 
@@ -247,13 +248,14 @@ it, and the lifecycle is what to attack:
   one drawn from the node's memory budget, with the per-image target as the
   thing that yields under it.
 
-  The press column looks like it rises with the idle count, and does not. The
-  levels were measured in time order, and a control run with the pool removed
-  gave 169, 147, 148, 143, 141ms, which brackets every figure in the table. No
-  press slowdown is detectable up to 50 idle containers. Memory binds first.
+  The test-run column looks like it rises with the idle count, and does not.
+  The levels were measured in time order, and a control run with the pool
+  removed gave 169, 147, 148, 143, 141ms, which brackets every figure in the
+  table. No slowdown is detectable up to 50 idle containers. Memory binds
+  first.
 
 A pool needs the runner to own the container lifecycle rather than delegate
-all of it to one docker run, so that a container can exist before the press
+all of it to one docker run, so that a container can exist before the test-run
 and its successor can be made after. Note the pool does not need --rm dropped
 to get that: --rm can be set at create time, and the daemon still removes each
 used container on its own.
@@ -310,26 +312,26 @@ still being collected.
 
 Finding: pool and socket compose, and 114ms becomes 14ms
 --------------------------------------------------------
-Every press spawns the docker CLI, which does HTTP against
+Every test-run spawns the docker CLI, which does HTTP against
 /var/run/docker.sock on the runner's behalf: create, attach, start, proxy the
 streams, and with --rm wait for the removal before exiting. The runner waits
 on that process, so it inherits all of it.
 
-time_press_via_daemon_api_vs_cli.rb does the same press four ways in one run,
-each creating with AutoRemove, feeding the same tgz and reading the same
+time_test_run_via_daemon_api_vs_cli.rb does the same test-run four ways in one
+run, each creating with AutoRemove, feeding the same tgz and reading the same
 payload back. Run on the host, so neither client is emulated:
 
-  press                                            ms
+  test-run                                         ms
   via docker CLI (docker run --rm)              114.1
   via docker CLI, pre-started (exec)             37.0
   via daemon API (AutoRemove, no wait)           81.1
   via daemon API, pre-started (exec)             14.2
 
-  off the press: preparing a spare               51.9
+  off the test-run: preparing a spare            51.9
 
 Three things follow.
 
-Talking to the socket directly saves about 48ms a press, some 40%, and gives
+Talking to the socket directly saves about 48ms a test-run, some 40%, and gives
 up nothing: AutoRemove is a property of the container, so the daemon still
 removes it whatever becomes of the client. No rm thread, no orphan sweep, no
 leak. That is more than the 36ms the parts predicted (21ms of removal wait
@@ -340,7 +342,7 @@ dominates everything the client does, and 37.0ms through the CLI is well under
 81.1ms through the socket. If only one is done, it should be the pool.
 
 Together they are worth far more than either. An API-driven pool answers a
-press in 14.2ms against today's 114.1ms, so the two compose rather than
+test-run in 14.2ms against today's 114.1ms, so the two compose rather than
 overlapping: the pool removes create and start, the socket removes the CLI
 process and the removal wait, and what is left is an exec and the body itself.
 Preparing the replacement container costs about 52ms, and that is the refill
@@ -353,7 +355,7 @@ containers. The pooled rows did not move.
 
 Every figure in this file is unemulated, and it has to stay that way to remain
 comparable. Running this probe inside the runner image, which is amd64 on an
-arm64 host, put the CLI press at 203.6ms and the pre-started press at 114.3ms,
+arm64 host, put the CLI test-run at 203.6ms and the pre-started one at 114.3ms,
 against 116.4 and 37.3 here. The API row barely moved (67.6 against 68.1),
 which says that path is daemon-side work rather than client CPU, and that most
 of what the CLI costs is the CLI's own process.
@@ -361,7 +363,7 @@ of what the CLI costs is the CLI's own process.
 
 Finding: the timeout path is simpler and tighter over the socket
 ----------------------------------------------------------------
-A timed-out press is the case the happy-path probes never touch.
+A timed-out test-run is the case the happy-path probes never touch.
 capture3_with_timeout.rb wraps Timeout.timeout around waiting for the CLI and
 then stops the container, which is what makes the CLI exit. See
 docs/the-timeout-path.md.
@@ -372,7 +374,7 @@ max_seconds 2, and reports how far past that the learner waits. Its cli row
 signals the CLI's process group as well as stopping the container, so read it
 as an upper bound on that path:
 
-  timed-out press                      total ms   overshoot ms
+  timed-out test-run                   total ms   overshoot ms
   cli: Timeout, kill group, stop         2081.2           81.2
   api: read deadline, stop inline        2046.5           46.5
   api: read deadline, stop threaded      2004.1            4.1
@@ -386,7 +388,7 @@ disposes of the container. The probe checks this rather than assuming it, and
 nothing survives.
 
 Two details for whoever writes it. The deadline has to be absolute and
-reapplied before each read: it bounds the whole press, and a container
+reapplied before each read: it bounds the whole test-run, and a container
 dribbling output would never trip a per-read timeout. And ruby 3.4, which the
 runner image has, offers IO#timeout= which raises IO::TimeoutError on its own;
 the probe uses IO.select only because it has to run on an older host ruby.
@@ -398,12 +400,12 @@ The saving is measured above; the price is not. It is: HTTP over a unix socket
 by hand, because Net::HTTP does not speak it; the hijacked bidirectional
 stream that attach returns; and the 8-byte header on each attach frame, which
 has to be demultiplexed to separate stdout from stderr.
-time_press_via_daemon_api_vs_cli.rb is a working sketch of all three and is
+time_test_run_via_daemon_api_vs_cli.rb is a working sketch of all three and is
 the place to start reading.
 
 It is less code than it sounds. That sketch is about 65 lines: a socket, an
 HTTP response reader, a one-shot request, the attach hijack, the frame
-demultiplexer, and the press itself. The container config it sends is a
+demultiplexer, and the test-run itself. The container config it sends is a
 further 35 lines, but that replaces the flag string in
 docker_run_cyber_dojo_sh_command rather than adding to it. Against those it
 displaces capture3_with_timeout.rb at 72 lines, process_spawner.rb at 11 and
@@ -411,11 +413,11 @@ pipe_maker.rb at 7. What the sketch does not carry is error handling, partial
 reads, or chunked responses, which it sidesteps with Connection: close.
 
 One detail that will bite: after writing the payload, the attach socket has to
-be half-closed, or the container's [tar -zxf -] never sees EOF and the press
-hangs for ever.
+be half-closed, or the container's [tar -zxf -] never sees EOF and the
+test-run hangs for ever.
 
-On sequencing: the target is both, since together they answer a press in
-14.2ms against 114.1ms today. A pool's press path is the same exec plumbing
+On sequencing: the target is both, since together they answer a test-run in
+14.2ms against 114.1ms today. A pool's test-run path is the same exec plumbing
 this change needs, so building the pool on the CLI means writing that plumbing
 twice. If only one is affordable it should be the pool, which is worth more
 alone than the client change is.

--- a/docs/start-points-without-a-manifest-rag-lambda.md
+++ b/docs/start-points-without-a-manifest-rag-lambda.md
@@ -1,0 +1,91 @@
+# Start-points without a manifest rag_lambda
+
+Which languages still make the runner read the red-amber-green lambda out of
+their image, rather than being handed it in the manifest.
+
+runner.rb branches on this per test-run:
+
+    if manifest.key?('rag_lambda')
+      colour, log_info = *@traffic_light.colour_from_lambda(manifest['rag_lambda'], *sss)
+    else
+      colour, log_info = *@traffic_light.colour_from_image(image_name, *sss)
+    end
+
+The else arm is the expensive one. It runs a whole container
+(`docker run --rm --entrypoint=cat <image> /usr/local/bin/red_amber_green.rb`)
+to read one file, and it is the last docker CLI caller on any request path.
+TrafficLight caches the result per image, so the cost falls on the first
+test-run for an image after a runner restart, not on every test-run.
+
+## The count
+
+Audited 2026-08-27, statically, over the working copies in
+~/repos/cyber-dojo-start-points. Each start-point is its own git repo, so
+there is no single sha to pin here.
+
+83 language start-points, each with a start_point/manifest.json. The three
+directories that have none (memory, pinned-checkout, shared-scripts) are not
+languages.
+
+  71  manifest has "rag_lambda": "red_amber_green.rb", and the file is present
+  12  manifest has no rag_lambda key, and no red_amber_green.rb beside it
+
+71 + 12 = 83. The 71 positives are what proves the search pattern, so the 12
+zeroes are a real absence rather than a miscalibrated grep.
+
+## The 12 on the image path
+
+  clang / clang++    clang-cgreen
+                     clangplusplus-catch
+                     clangplusplus-cgreen
+                     clangplusplus-googletest
+                     clangplusplus-igloo
+
+  java               java-cucumberpico
+                     java-cucumberspring
+                     java-jmock
+                     java-mockito
+                     java-powermockito
+                     java-sqlite
+
+  other              visual-basic-nunit
+
+Two clusters rather than a scatter. Eleven of the twelve are clang or java,
+which points at a shared cause in how those image families were built rather
+than at twelve independent omissions. Finding that cause is likely to fix them
+as a batch.
+
+## What is not established here
+
+The manifest value is a filename, "red_amber_green.rb", not the lambda source.
+runner.rb passes manifest['rag_lambda'] straight into colour_from_lambda as
+lambda_source, so something between the start-point and the runner substitutes
+the file's content for its name. That step has not been read, and until it has,
+this audit says which start-points carry the file, not that all 71 reach the
+runner as source.
+
+docs/api.md documents only the image route, at /usr/local/bin/red_amber_green.rb.
+The rag_lambda manifest field is undocumented there.
+
+docs/rag-functions-into-manifest.txt is the plan this audit measures progress
+against. It goes further than a manifest field: rag functions in JavaScript,
+run in the browser, with a ragger service as the fallback for images that
+cannot be upgraded. Those 12 are exactly the population that fallback exists
+for.
+
+## Zero here does not delete the image route
+
+Reaching 0 of 83 would empty the else arm of everything a start-point can
+reach, and no further. The route stays reachable for anything the start-points
+do not cover: a fork of an old kata whose manifest predates the field, and an
+image someone built themselves. Neither can be counted by an audit like this
+one, and neither can be upgraded by whoever maintains the runner.
+
+So converting the 12 buys the common case, not the branch. Deleting
+colour_from_image means moving that fallback somewhere else, which is what the
+ragger service in docs/rag-functions-into-manifest.txt is for. Until it exists,
+the image route is load-bearing however many start-points carry the field.
+
+This is what decides step 3 of docs/dropping-the-dind-base-image.md, which
+wants the route empty so the last docker CLI caller converts by deletion.
+Empty of start-points is not empty of callers.

--- a/docs/the-timeout-path.md
+++ b/docs/the-timeout-path.md
@@ -1,6 +1,6 @@
 # The timeout path
 
-How a timed-out press ends, and why it is shaped this way.
+How a timed-out test-run ends, and why it is shaped this way.
 
 ## What happens
 

--- a/source/server/daemon_run.rb
+++ b/source/server/daemon_run.rb
@@ -16,7 +16,21 @@ class DaemonRun
   # The daemon would not do what it was asked. Carrying on regardless means
   # working with no container id, and failing later somewhere that says
   # nothing about why.
+  #
+  # It carries the status code because which refusal it is decides what the
+  # runner does next. 404 is the daemon saying the image is not on the node,
+  # which is the only refusal that says anything about the image at all: the
+  # image is checked before the name, so every other code is reached having
+  # already found it.
   class DaemonRefused < RuntimeError
+    def initialize(code, message)
+      @code = code
+      super(message)
+    end
+
+    attr_reader :code
+
+    NO_SUCH_IMAGE = 404
   end
 
   def initialize(client)
@@ -45,7 +59,7 @@ class DaemonRun
       "/containers/create?name=#{container_name}",
       CyberDojoShContainerConfig.create_config(id, image_name)
     )
-    raise DaemonRefused, "create answered #{code}: #{body}" unless code.between?(200, 299)
+    raise DaemonRefused.new(code, "create answered #{code}: #{body}") unless code.between?(200, 299)
 
     JSON.parse(body)['Id']
   end

--- a/source/server/dispatcher.rb
+++ b/source/server/dispatcher.rb
@@ -1,4 +1,5 @@
 require 'json'
+require_relative 'tagged_image_name'
 
 class Dispatcher
   class RequestError < RuntimeError
@@ -21,6 +22,10 @@ class Dispatcher
     end
   rescue JSON::JSONError
     raise request_error('body is not JSON')
+  rescue Docker::MalformedImageName
+    raise request_error('malformed image_name')
+  rescue Docker::UnversionedImageName
+    raise request_error('unversioned image_name')
   rescue Exception => e
     if (r = e.message.match('(missing|unknown) keyword(s?): (.*)'))
       raise request_error("#{r[1]} argument#{r[2]}: #{r[3]}")

--- a/source/server/externals/random.rb
+++ b/source/server/externals/random.rb
@@ -4,8 +4,8 @@ class Random
   # SecureRandom asks the OS for its bytes on every call, rather than drawing
   # on state this object is holding. config.ru builds the Context while puma
   # preloads the app, and puma then forks its workers, so state held here
-  # would be identical in every one of them: two workers answering presses of
-  # the same kata id would build the same container name, and the daemon
+  # would be identical in every one of them: two workers answering test-runs
+  # of the same kata id would build the same container name, and the daemon
   # refuses the second of them.
   def hex8
     SecureRandom.hex(4)

--- a/source/server/externals/unix_socket_http.rb
+++ b/source/server/externals/unix_socket_http.rb
@@ -4,7 +4,7 @@ require 'socket'
 # Speaks HTTP over a unix socket, which Net::HTTP does not do. The docker
 # daemon listens on one, and running cyber-dojo.sh over it costs about 33ms
 # less than spawning the docker CLI to do the same.
-# See docs/profiling/time_press_via_daemon_api_vs_cli.rb
+# See docs/profiling/time_test_run_via_daemon_api_vs_cli.rb
 class UnixSocketHttp
   def initialize(socket_path)
     @socket_path = socket_path

--- a/source/server/node.rb
+++ b/source/server/node.rb
@@ -8,10 +8,15 @@ class Node
     ls, stderr, status = sheller.capture(command)
     raise stderr.to_s unless status.zero?
 
-    ls.split("\n").sort.uniq - ['<none>:<none>']
+    # A <none> tag names no image the runner could ever be asked for,
+    # whether or not the repository half is set. Both are dropped so that
+    # what this answers is only names a manifest could hold.
+    ls.split("\n").sort.uniq.reject { |image_name| image_name.end_with?(NO_TAG) }
   end
 
   private
+
+  NO_TAG = ':<none>'.freeze
 
   def sheller
     @context.sheller

--- a/source/server/puller.rb
+++ b/source/server/puller.rb
@@ -16,7 +16,16 @@ class Puller
     @pulled.add(image_name)
   end
 
+  # Drops the belief that image_name is on the node, so the next pull_image
+  # pulls it rather than answering :pulled. What @pulled holds is a belief:
+  # config.ru seeds it from `docker image ls` at boot, and an image removed
+  # after that leaves no trace in it.
+  def forget_image(image_name)
+    @pulled.delete(image_name)
+  end
+
   def pull_image(id:, image_name:)
+    ::Docker.assert_image_name(image_name)
     image_name = ::Docker.tagged_image_name(image_name)
     if @pulled.include?(image_name)
       :pulled

--- a/source/server/runner.rb
+++ b/source/server/runner.rb
@@ -2,6 +2,7 @@ require_relative 'daemon_run'
 require_relative 'files_delta'
 require_relative 'home_files'
 require_relative 'sandbox'
+require_relative 'tagged_image_name'
 require_relative 'tarfile_reader'
 require_relative 'tgz'
 require_relative 'traffic_light'
@@ -15,6 +16,11 @@ class Runner
 
   def run_cyber_dojo_sh(id:, files:, manifest:)
     image_name = manifest['image_name']
+    # Checked here rather than left to pull_image's own tagging, so that what
+    # the manifest says is this method's business and a run never depends on
+    # how far a bad name happens to travel before something objects.
+    ::Docker.assert_image_name(image_name)
+
     return empty_result(:pulling, 'pulling', {}) unless puller.pull_image(id: id, image_name: image_name) == :pulled
 
     run, files_in = run_cyber_dojo_sh_inner(id, files, manifest)
@@ -46,6 +52,11 @@ class Runner
     # and nothing the kata did wrong. The learner is owed a traffic light
     # rather than a 500, and what the daemon said belongs in the log rather
     # than in the browser.
+    # Forgetting the image is what lets a later test-run pull it again. This
+    # refusal is the only sign the runner gets that what @pulled believes
+    # about the node is wrong, and believing it anyway makes every later
+    # test-run for this image faulty too.
+    puller.forget_image(image_name) if e.code == DaemonRun::DaemonRefused::NO_SUCH_IMAGE
     log(id: id, image_name: image_name, error: e.message)
     faulty_result({})
   rescue Zlib::GzipFile::Error, Gem::Package::TarInvalidError => e

--- a/source/server/tagged_image_name.rb
+++ b/source/server/tagged_image_name.rb
@@ -1,25 +1,75 @@
 # mix-in
 module Docker
+  # str does not name a docker image, so there is nothing to tag. Saying so
+  # is what keeps a caller's bad argument from surfacing as a NoMethodError
+  # raised on the nil that str.match answered.
+  class MalformedImageName < RuntimeError
+  end
+
+  # str names a docker image, but names whichever image was pushed to
+  # :latest rather than one particular image. A start-point pointing at
+  # :latest can change underneath the kata, so the runner will not take one.
+  class UnversionedImageName < RuntimeError
+  end
+
   module_function
 
+  LATEST = 'latest'.freeze
+
+  # Raises unless str is a docker image name pinned to a tag other than
+  # :latest, which is what the runner accepts from outside. Every way of
+  # asking for :latest collapses to one check here, since tagged_image_name
+  # answers an untagged name with the :latest it means. tagged_image_name is
+  # what answers the malformed case.
+  #
+  # That takes a digest with no tag, eg name@sha256:..., down with it, and a
+  # digest pins harder than any tag does. It goes anyway, because config.ru
+  # seeds Puller's set of images-present-on-the-node from `docker image ls`,
+  # which only ever answers repo:tag. A digest-only name matches nothing in
+  # that seed, so it is pulled afresh after every restart. One way to name a
+  # start-point, and one the seed can recognise, is worth more here than the
+  # stronger pin.
+  def assert_image_name(str)
+    raise UnversionedImageName, str.inspect if tag_of(tagged_image_name(str)) == LATEST
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  # Answers the tag of an image name known to carry one. The digest, which
+  # holds a colon of its own, comes off first; a registry's :port cannot be
+  # last, so what follows the last remaining colon is the tag.
+  def tag_of(tagged)
+    tagged.split('@', 2).first.split(':').last
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  # The image_names harvested from the nodes have an
+  # explicit :latest tag. The image_name in pull_image()
+  # and run_cyber_dojo_sh()'s manifest must match.
+  # eg 'cdf/gcc_assert' ==> 'cdf/gcc_assert:latest'
   def tagged_image_name(str)
-    # The image_names harvested from the nodes have an
-    # explicit :latest tag. The image_name in pull_image()
-    # and run_cyber_dojo_sh()'s manifest must match.
-    # eg 'cdf/gcc_assert' ==> 'cdf/gcc_assert:latest'
+    raise MalformedImageName, str.inspect unless image_name?(str)
+
+    name, match = name_and_match(str)
+    "#{name}:#{match[8] || LATEST}#{match[9]}"
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - - - - - - - -
+
+  # Answers the name as written, and the REMOTE_NAME match holding its tag
+  # and digest. A registry host comes off first, REMOTE_NAME not describing
+  # one, and is put back on the answered name.
+  def name_and_match(str)
     index = str.index('/')
     if index.nil? || remote_name?(str[0...index])
       match = str.match(REMOTE_NAME)
-      name = match[1]
+      [match[1], match]
     else
       host_name, remote_name = cut(str, index)
       match = remote_name.match(REMOTE_NAME)
-      name = "#{host_name}/#{match[1]}"
+      ["#{host_name}/#{match[1]}", match]
     end
-    tag = match[8]
-    digest = match[9]
-    tag = 'latest' if tag.nil?
-    "#{name}:#{tag}#{digest}"
   end
 
   # - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/test/client/container_properties_test.rb
+++ b/test/client/container_properties_test.rb
@@ -6,7 +6,9 @@ class ContainerPropertiesTest < TestBase
   | requires bash, won't run in sh
   ) do
     set_context
-    any_image_without_bash = 'alpine:latest' # must have been pulled onto node before server started
+    # Pulled onto the node before the server started, by
+    # bin/setup_dependent_images.sh, which names the same version.
+    any_image_without_bash = 'alpine:3.24'
     run_cyber_dojo_sh(image_name: any_image_without_bash)
     refute timed_out?, pretty_result(:timed_out)
     assert stdout.empty?, pretty_result(:stdout)

--- a/test/doubles/all.rb
+++ b/test/doubles/all.rb
@@ -1,5 +1,6 @@
 require_relative 'bash_sheller_stub'
 require_relative 'daemon_stub'
+require_relative 'puller_spy'
 require_relative 'rack_request_stub'
 require_relative 'random_hex8_stub'
 require_relative 'stdout_logger_spy'

--- a/test/doubles/puller_spy.rb
+++ b/test/doubles/puller_spy.rb
@@ -1,0 +1,21 @@
+class PullerSpy
+  # as passed to set_context(puller:), recording whether the puller was
+  # consulted at all.
+  #
+  # Answers :pulling, which is what stops a run that did not validate its
+  # image_name at runner.rb's pulling gate rather than letting it reach the
+  # daemon with a name no image could have.
+
+  def initialize
+    @called = false
+  end
+
+  def pull_image(id:, image_name:)
+    @called = true
+    :pulling
+  end
+
+  def called?
+    @called
+  end
+end

--- a/test/server/check_test_metrics.rb
+++ b/test/server/check_test_metrics.rb
@@ -25,21 +25,21 @@ def table_data
 
   [
     [ nil ],
-    [ 'test.count',    stats['test_count'],    '>=', 131 ],
+    [ 'test.count',    stats['test_count'],    '>=', 139 ],
     [ 'test.duration', stats['total_time'],    '<=',  10 ],
     [ nil ],
     [ 'test.failures', stats['failure_count'], '<=',  0 ],
     [ 'test.errors',   stats['error_count'  ], '<=',  0 ],
     [ 'test.skips',    stats['skip_count'   ], '<=',  0 ],
     [ nil ],
-    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 1133 ],
+    [ 'test.lines.total',      test_cov['lines'   ]['total' ], '<=', 1184 ],
     [ 'test.lines.missed',     test_cov['lines'   ]['missed'], '<=',    0 ],
     [ 'test.branches.total',   test_cov['branches']['total' ], '<=',    8 ],
     [ 'test.branches.missed',  test_cov['branches']['missed'], '<=',    0 ],
     [ nil ],
-    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 662 ],
+    [ 'code.lines.total',      code_cov['lines'   ]['total' ], '<=', 684 ],
     [ 'code.lines.missed',     code_cov['lines'   ]['missed'], '<=', 0   ],
-    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 82  ],
+    [ 'code.branches.total',   code_cov['branches']['total' ], '<=', 86  ],
     [ 'code.branches.missed',  code_cov['branches']['missed'], '<=', 0   ],
   ]
 end

--- a/test/server/hex8_per_forked_worker_test.rb
+++ b/test/server/hex8_per_forked_worker_test.rb
@@ -7,7 +7,7 @@ class Hex8PerForkedWorkerTest < TestBase
   | because config.ru builds the Context while puma preloads the app, and
   | puma then forks Etc.nprocessors workers, each holding a Random whose
   | state is identical to every one of its siblings
-  | two workers answering presses of the same kata id would otherwise build
+  | two workers answering test-runs of the same kata id would otherwise build
   | the same container name, and the daemon refuses the second with a 409
   ) do
     seed = 1234

--- a/test/server/node_test.rb
+++ b/test/server/node_test.rb
@@ -21,6 +21,22 @@ class NodeTest < TestBase
 
   # - - - - - - - - - - - - - - - - - - - - -
 
+  test '3q1Ps7', %w[image_names with a repository and a <none> tag
+                    are filtered out too, being no more nameable
+                    than <none>:<none>] do
+    set_context(sheller: BashShellerStub.new)
+    untagged = %w[
+      cyberdojo/runner:<none>
+      registry.example.com:5000/gcc_assert:<none>
+    ]
+    tainted = (expected + untagged).shuffle
+    sheller.capture(DOCKER_IMAGE_LS_COMMAND) { [tainted.join("\n"), '', 0] }
+    actual = node.image_names
+    assert_equal expected, actual
+  end
+
+  # - - - - - - - - - - - - - - - - - - - - -
+
   test '3q1Ps5', %w[image_names populate puller in config.ru] do
     set_context(sheller: BashShellerStub.new)
     sheller.capture(DOCKER_IMAGE_LS_COMMAND) { [expected.join("\n"), '', 0] }

--- a/test/server/rack_dispatcher_test.rb
+++ b/test/server/rack_dispatcher_test.rb
@@ -138,6 +138,46 @@ class RackDispatcherTest < TestBase
 
   # - - - - - - - - - - - - - - - - -
 
+  test 'D06BB3',
+       %w[malformed image_name becomes 400 exception
+          rather than reaching tagged_image_name and becoming a 500] do
+    expected = 'malformed image_name'
+    bad_image_name = 'UPPERCASE/name:latest'
+
+    assert_rack_call_400_exception(
+      expected, 'pull_image',
+      { id: id58, image_name: bad_image_name }.to_json
+    )
+
+    args = run_cyber_dojo_sh_args
+    args['manifest']['image_name'] = bad_image_name
+    assert_rack_call_400_exception(expected, 'run_cyber_dojo_sh', args.to_json)
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test 'D06BB4',
+       %w[image_name resolving to :latest becomes 400 exception
+          because :latest names whatever was pushed last,
+          which is a start-point with no version] do
+    expected = 'unversioned image_name'
+    [
+      'cyberdojofoundation/gcc_assert',        # no tag, so :latest
+      'cyberdojofoundation/gcc_assert:latest'  # said out loud, no better
+    ].each do |unversioned|
+      assert_rack_call_400_exception(
+        expected, 'pull_image',
+        { id: id58, image_name: unversioned }.to_json
+      )
+
+      args = run_cyber_dojo_sh_args
+      args['manifest']['image_name'] = unversioned
+      assert_rack_call_400_exception(expected, 'run_cyber_dojo_sh', args.to_json)
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
   test 'D06AA6',
        %w[missing argument becomes 400 exception] do
     f = 'run_cyber_dojo_sh'

--- a/test/server/run_daemon_refused_test.rb
+++ b/test/server/run_daemon_refused_test.rb
@@ -22,4 +22,23 @@ class RunDaemonRefusedTest < TestBase
     assert_equal Runner::STATUS[:faulty].to_s, run['status']
     assert_includes @logger.logged, 'already in use'
   end
+
+  test 'd4Hb11', %w[
+  | a create refused with 409 leaves the pulled set alone
+  | because the daemon checks the image before the name,
+  | so reaching a name conflict proves the image is on the node
+  ] do
+    set_context(
+      logger: @logger = StdoutLoggerSpy.new,
+      daemon: DaemonStub.new(
+        create_code: 409,
+        create_body: '{"message":"Conflict. The container name is already in use"}'
+      )
+    )
+    puller.add(image_name)
+
+    run_cyber_dojo_sh
+
+    assert_equal [image_name], puller.image_names
+  end
 end

--- a/test/server/run_missing_image_invalidates_pulled_test.rb
+++ b/test/server/run_missing_image_invalidates_pulled_test.rb
@@ -1,0 +1,25 @@
+require_relative '../test_base'
+
+class RunMissingImageInvalidatesPulledTest < TestBase
+
+  test 'F7kR2m', %w(
+  | when the daemon answers 404 to create, the image is not on the node,
+  | so it is dropped from puller's pulled set
+  | and the next test-run pulls it again rather than failing for ever
+  ) do
+    set_context(
+      logger: @logger = StdoutLoggerSpy.new,
+      daemon: DaemonStub.new(
+        create_code: 404,
+        create_body: %({"message":"No such image: #{image_name}"})
+      )
+    )
+    puller.add(image_name)
+    assert_equal [image_name], puller.image_names
+
+    run_cyber_dojo_sh
+
+    assert_equal [], puller.image_names
+    assert_includes @logger.logged, "No such image: #{image_name}"
+  end
+end

--- a/test/server/run_validates_image_name_before_pulling_test.rb
+++ b/test/server/run_validates_image_name_before_pulling_test.rb
@@ -1,0 +1,18 @@
+require_relative '../test_base'
+
+class RunValidatesImageNameBeforePullingTest < TestBase
+
+  test 'B3nQ7k', %w[
+  | run_cyber_dojo_sh rejects a malformed manifest image_name itself,
+  | before the puller is consulted,
+  | so the rejection does not rest on pull_image reaching tagged_image_name
+  ] do
+    set_context(puller: spy = PullerSpy.new)
+
+    assert_raises(Docker::MalformedImageName) do
+      run_cyber_dojo_sh(image_name: 'UPPERCASE/name:latest')
+    end
+
+    refute spy.called?, 'the puller was consulted before the image_name was validated'
+  end
+end

--- a/test/server/tagged_image_name_test.rb
+++ b/test/server/tagged_image_name_test.rb
@@ -45,6 +45,46 @@ class TaggedImageNameTest < TestBase
 
   # - - - - - - - - - - - - - - - - -
 
+  # A digest carries a colon, and a registry can carry a :port, so the tag is
+  # not simply what follows the last colon. These pin every shape they make.
+  DIGEST = '@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef'.freeze
+
+  test '9g8005', %w[accepted when pinned to a tag that is not :latest,
+                    and the tag read is the one written
+                    rather than a digest's or a registry port's] do
+    [
+      'cyberdojofoundation/gcc_assert:1a2b3c4',
+      "cyberdojofoundation/gcc_assert:1a2b3c4#{DIGEST}",
+      'localhost:5000/gcc_assert:1a2b3c4',
+      "localhost:5000/gcc_assert:1a2b3c4#{DIGEST}"
+    ].each do |image_name|
+      Docker.assert_image_name(image_name)
+      assert_equal '1a2b3c4', Docker.tag_of(image_name), image_name
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
+  test '9g8006', %w[rejected when it resolves to :latest,
+                    whether :latest is said out loud, left unsaid,
+                    or hidden behind a digest] do
+    [
+      'cyberdojofoundation/gcc_assert',
+      'cyberdojofoundation/gcc_assert:latest',
+      "cyberdojofoundation/gcc_assert#{DIGEST}",
+      "cyberdojofoundation/gcc_assert:latest#{DIGEST}",
+      'localhost:5000/gcc_assert',
+      'localhost:5000/gcc_assert:latest',
+      "localhost:5000/gcc_assert:latest#{DIGEST}"
+    ].each do |image_name|
+      assert_raises(Docker::UnversionedImageName, image_name) do
+        Docker.assert_image_name(image_name)
+      end
+    end
+  end
+
+  # - - - - - - - - - - - - - - - - -
+
   test '9g8004', %w[tagged with :latest when no tag and a digest] do
     Test::Data::ImageNames::TAG_NO_DIGEST_YES.each do |image_name|
       assert Docker.image_name?(image_name), image_name

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -215,7 +215,7 @@ class TestBase < Id58TestBase
                         changed: { 'cyber-dojo.sh' => script }
                       })
     refute timed_out?, pretty_result(:timed_out)
-    # A faulty run that gives no account of itself is one the press never
+    # A faulty run that gives no account of itself is one the test-run never
     # happened for, eg the daemon refusing to create the container. It answers
     # empty stdout/stderr, so a test that goes on to look at the payload fails
     # somewhere further down saying only that what it wanted is not there.


### PR DESCRIPTION
…missing

  Two failures with the same root: the runner trusted an image_name it had no
  business trusting.

  A name that is not a docker image name was a 500, not a 400. tagged_image_name
  called [] on the nil its regex answered, reachable from both /pull_image and
  /run_cyber_dojo_sh with nothing validating between. The image_name? predicate
  for exactly this had been sitting there with no caller.

  A name pinned to :latest was accepted, and names whichever image was pushed
  last, so the kata it sets up can change underneath the learner. Refused now
  however it is asked for: written out, left off, or left off in front of a
  digest. All three resolve to :latest, so one check catches them. node.rb also
  stops harvesting names tagged <none>, no more nameable than the <none>:<none>
  it already dropped.

  Recovery was worse. Puller's @pulled is add-only, and since the run path moved
  to the daemon socket nothing else pulls: POST /containers/create answers 404
  rather than pulling, which the docker CLI used to do client-side. An image
  removed after boot left every later test-run for it faulty until the worker
  restarted. A 404 now forgets the image so the next test-run pulls it again,
  and only a 404: the daemon checks the image before the name, so a 409 name
  conflict is proof the image is there.

  Self-hosted servers naming their images untagged will start getting 400s.
  docs/api.md says so, and
  docs/a-missing-image-recovers-only-through-puller.md carries the reasoning
  and the probe output behind it.