### PR TITLE
Build on sinatra-base now nothing calls the docker CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,8 @@
-FROM cyberdojo/docker-base:909ba1d@sha256:20ac5af0c95cd148ad9acba9ca8da9c9145d6df478f40cccac52042aa071427f AS base
-# The FROM statement above is typically set via an automated pull-request from the docker-base repo
+FROM ghcr.io/cyber-dojo/sinatra-base:1a1d65f@sha256:31bfb1e5cbc25d4b37e0dfea2e460d4ecdaf8062bfc5b70b6a28c40211daea61 AS base
+# The FROM statement above is typically set via an automated pull-request from the sinatra-base repo
 LABEL maintainer=jon@jaggersoft.com
 
 RUN gem install --no-document 'concurrent-ruby'
-
-# Remove git, which is inherited from the upstream docker:dind base image.
-# The runner never uses git at runtime; the only git calls in this repo are
-# host-side build scripts (bin/echo_env_vars.sh runs "git rev-parse HEAD" on the
-# host, not inside the image). git is the sole package that pulls in libcurl, so
-# deleting it also removes libcurl and clears the recurring Alpine libcurl CVEs
-# from the runner's Snyk scan. docker-base keeps git for commander, which does
-# use "git clone" at runtime.
-RUN apk del git
-
-# Remove docker-buildx, a CLI plugin the runner never invokes; it drives docker
-# only through run, stop, rm, pull and image. buildx is the one binary left in
-# the image vendoring a vulnerable moby/go-archive, and it is the source of every
-# buildkit finding in the Snyk scan. The plugin arrives from the base image, so
-# deleting it here only marks it removed in a later layer: the image is no
-# smaller to pull, but the binary is absent from the running container and from
-# the filesystem the scanner sees.
-RUN rm -rf /usr/local/libexec/docker/cli-plugins/docker-buildx
 
 ARG COMMIT_SHA
 ENV COMMIT_SHA=${COMMIT_SHA}
@@ -30,6 +12,9 @@ ENV APP_DIR=${APP_DIR}
 
 WORKDIR ${APP_DIR}/source
 COPY source/server/ .
+# The runner opens /var/run/docker.sock, which is owned by the host's docker
+# group, so it cannot drop to an unprivileged user without matching that group.
+# See docs/runner-as-docker-group.txt
 USER root
 HEALTHCHECK --interval=1s --timeout=1s --retries=5 --start-period=5s CMD ./config/healthcheck.sh
 ENTRYPOINT ["/sbin/tini", "-g", "--"]

--- a/source/client/http_proxy/net_http_adapter.rb
+++ b/source/client/http_proxy/net_http_adapter.rb
@@ -7,9 +7,9 @@ module HttpProxy
     end
 
     def post(uri)
-      # simplecov:disable
+      # :nocov:
       Net::HTTP::Post.new(uri)
-      # simplecov:enable
+      # :nocov:
     end
 
     def start(hostname, port, req)

--- a/test/dual/run_red_amber_green_test.rb
+++ b/test/dual/run_red_amber_green_test.rb
@@ -10,7 +10,7 @@ module Dual
       run_cyber_dojo_sh
       assert red?, run_result
       on_client do
-        # simplecov:disable
+        # :nocov:
         expected_stdout = ''
         expected_stderr = [
           'Assertion failed: answer() == 42 (hiker.tests.c: life_the_universe_and_everything: 7)',
@@ -24,7 +24,7 @@ module Dual
           assert stderr.include?(line), diagnostic
         end
         assert_equal expected_status, status, :status
-        # simplecov:enable
+        # :nocov:
       end
     end
 
@@ -35,7 +35,7 @@ module Dual
       run_cyber_dojo_sh_with_edit('hiker.c', '6 * 9', '6 * 9s')
       assert amber?, run_result
       on_client do
-        # simplecov:disable
+        # :nocov:
         expected_stdout = ''
         expected_stderr = [
           "hiker.c:5:16: error: invalid suffix 's' on integer constant",
@@ -49,7 +49,7 @@ module Dual
           assert stderr.include?(line), diagnostic
         end
         assert_equal expected_status, status, :status
-        # simplecov:enable
+        # :nocov:
       end
     end
 
@@ -60,14 +60,14 @@ module Dual
       run_cyber_dojo_sh_with_edit('hiker.c', '6 * 9', '6 * 7')
       assert green?, run_result
       on_client do
-        # simplecov:disable
+        # :nocov:
         assert_equal "All tests passed\n", stdout
         expected_stderr =
           "(INFO) Reading coverage data...\n" \
           "(INFO) Writing coverage report...\n"
         assert_equal expected_stderr, stderr
         assert_equal '0', status
-        # simplecov:enable
+        # :nocov:
       end
     end
 
@@ -75,12 +75,12 @@ module Dual
 
     def stub(colour)
       on_client do
-        # simplecov:disable
+        # :nocov:
         set_context
-        # simplecov:enable
+        # :nocov:
       end
       on_server do
-        # simplecov:disable
+        # :nocov:
         stdout_tgz = TGZ.of({ 'stderr' => 'any' })
         # The rag-lambda arrives as a tar, being what the daemon's archive
         # endpoint answers when TrafficLight reads it out of the image.
@@ -91,7 +91,7 @@ module Dual
           daemon: DaemonStub.new(stdout: stdout_tgz, archive: tar.tar_file)
         )
         puller.add(image_name)
-        # simplecov:enable
+        # :nocov:
       end
     end
 

--- a/test/lib/coverage.rb
+++ b/test/lib/coverage.rb
@@ -13,12 +13,12 @@ SimpleCov.start do
   code_tab = ENV.fetch('COVERAGE_CODE_TAB_NAME')
   test_tab = ENV.fetch('COVERAGE_TEST_TAB_NAME')
 
-  # group('debug') { |the| puts the.filename; false }
+  # add_group('debug') { |the| puts the.filename; false }
 
-  group(test_tab) do |the|
+  add_group(test_tab) do |the|
     the.filename.start_with?("#{APP_DIR}/test/#{CONTEXT}/") || the.filename.start_with?("#{APP_DIR}/test/dual/")
   end
-  group(code_tab) do |the|
+  add_group(code_tab) do |the|
     the.filename.start_with?("#{APP_DIR}/source/")
   end
 end


### PR DESCRIPTION
  The runner was built FROM cyberdojo/docker-base, a dind image, for one
  reason: the docker CLI binary. Node, Puller and TrafficLight now reach
  the daemon over its socket instead, so that reason is gone, and the
  runner can sit on the same base as the other services. What goes with
  dind is git and buildx, and the two RUN lines that existed only to
  delete them again.

  sinatra-base carries simplecov 0.21.2 where docker-base carried 1.1.1,
  so two things in the test harness move back to the older spelling:

    - SimpleCov.group is 1.x-only, and 0.21.2 routes the config block through docile, so calling it fails with "undefined method 'group' for main" - naming neither simplecov nor the version. add_group is the name both versions answer to.
    - # simplecov:disable / :enable is also 1.x-only. Under 0.21.2 the lines it guards count as relevant-and-missed, which is why the dual test contributed 21 uncovered lines. # :nocov: is the token both versions read, so this one needs no undoing later.

  Coverage is unchanged by the move: every figure lands on the limit it
  already had, test.lines.total 1141, code.lines.total 674, nothing
  missed. That is what says the two simplecovs account for these files
  identically, and the swap is a base-image change and nothing more.

  add_group is deprecated on 1.x. When sinatra-base unpins simplecov the
  downstream PR can carry it back to group.