### PR TITLE
Use the simplecov 1.x spellings now the base image carries it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR ${APP_DIR}/source
 COPY source/server/ .
 # The runner opens /var/run/docker.sock, which is owned by the host's docker
 # group, so it cannot drop to an unprivileged user without matching that group.
-# See docs/runner-as-docker-group.txt
+# See docs/docker-socket-privilege.md
 USER root
 HEALTHCHECK --interval=1s --timeout=1s --retries=5 --start-period=5s CMD ./config/healthcheck.sh
 ENTRYPOINT ["/sbin/tini", "-g", "--"]

--- a/docs/docker-socket-privilege.md
+++ b/docs/docker-socket-privilege.md
@@ -1,0 +1,93 @@
+# The docker socket, and why the runner runs as root
+
+The runner's `Dockerfile` ends with `USER root`. Saver and the other services
+drop to an unprivileged user, so the runner looks like the odd one out. It is,
+and this is what it would take to change, and why the obvious change is worth
+less than it appears.
+
+## Why root today
+
+`docker-compose.yml` bind-mounts the host's socket into the container:
+
+    - /var/run/docker.sock:/var/run/docker.sock
+
+A bind-mounted socket keeps the ownership it has on the host, expressed as raw
+numeric ids. On a developer machine running Docker Desktop that is:
+
+    srw-rw---- 1 0 0 /var/run/docker.sock
+
+root:root, mode 660. No group holds any permission on it, so no group is
+joinable, and only uid 0 can open it.
+
+Three places currently agree that the runner is root, and all three have to
+agree or the container cannot reach the daemon:
+
+- `Dockerfile`, `USER root`
+- `bin/echo_env_vars.sh`, `CYBER_DOJO_RUNNER_SERVER_USER=root`, which
+  `docker-compose.yml` passes as the service's `user:`
+- `deployment/terraform/deployment.tf`, which sets no `user` at all, so ECS
+  runs the image's own
+
+## Why a docker group does not solve it
+
+On a Linux host the socket is `root:docker` rather than root:root, so the
+question becomes whether the runner can run as a user in that group. See
+https://estl.tech/accessing-docker-from-a-kubernetes-pod-68996709c04b
+
+The group's GID is a property of the host, not of the image. It differs between
+distributions and between AMIs. Putting it in the `Dockerfile` makes the image
+correct for one host and wrong for the next, which is the opposite of what a
+built artifact should be. The mechanism that gets it right supplies the GID at
+deploy time instead, as ECS `user: "uid:gid"` or compose `group_add:`, which
+puts a host fact in the task definition where it belongs.
+
+That still leaves the developer machine, where the socket has no group to join,
+so the local and deployed configurations would have to differ on exactly the
+thing they should agree about. A runner that is root locally and non-root in
+production is a runner whose permission behaviour is only ever tested in one of
+the two places it runs.
+
+## Why it would buy little anyway
+
+Reaching the docker daemon is equivalent to being root on the host. Anything
+that can create a container can create a privileged one with the host's
+filesystem mounted, whatever uid asked for it. So dropping the runner to a
+non-root uid, while leaving the socket mounted, moves nothing that an attacker
+who reached the runner would care about. The privilege is the socket, not the
+uid.
+
+## What would reduce it
+
+Refusing what the runner does not use. Every call it makes on the daemon is now
+a `UnixSocketHttp#request` or `#attach` with a literal path, so the whole set
+can be read off the source:
+
+| Endpoint | Caller |
+| --- | --- |
+| `GET /images/json` | `node.rb` |
+| `POST /images/create?fromImage=` | `puller.rb` |
+| `POST /containers/create` | `daemon_run.rb`, `traffic_light.rb` |
+| `POST /containers/{id}/attach` | `daemon_run.rb` |
+| `POST /containers/{id}/start` | `daemon_run.rb` |
+| `POST /containers/{id}/stop` | `daemon_run.rb` |
+| `GET /containers/{id}/archive` | `traffic_light.rb` |
+| `DELETE /containers/{id}` | `traffic_light.rb` |
+
+A proxy in front of the socket that allows those and refuses everything else
+removes the privileged-container escape, and it does so without the runner
+having to stop being root. Note what it does not remove: `POST
+/containers/create` is on the list because the runner's whole job is creating
+containers, so a proxy has to judge the config it is asked for rather than only
+the path. `CyberDojoShContainerConfig` is where the runner's own answer to that
+question already lives.
+
+Enumerating this list was not practical while the runner spawned the docker
+CLI, because the CLI's flags do not map one-to-one onto endpoints and the CLI
+is free to call others. It became possible when the last CLI caller went.
+
+## Not settled here
+
+Which proxy, and whether the create-config check can be expressed in it. Also
+whether ECS on the deployed AMI presents the socket as root:docker at all: this
+document only measures Docker Desktop, and the deployed host has not been
+checked.

--- a/docs/dropping-the-dind-base-image.md
+++ b/docs/dropping-the-dind-base-image.md
@@ -132,10 +132,10 @@ request, tar for tar-piping coverage out of tmpfs.
 
 Points to settle before committing to the change:
 
-- The runner must keep `USER root`, or run as a user in the group owning
-  `/var/run/docker.sock`. Saver drops to an unprivileged `saver` user; the
-  runner cannot do the same without matching that group. See
-  `docs/runner-as-docker-group.txt`.
+- The runner keeps `USER root`, because the socket it opens is root-owned and
+  the group that would replace root is a property of the host rather than of
+  the image. See `docs/docker-socket-privilege.md`, which also says why doing
+  it would buy less than it looks like it would.
 - Ruby changes from Alpine's `ruby-dev` package to the official
   `ruby:4.0.5-alpine3.24` image, and the inherited gem set changes from
   `docker-base`'s Gemfile to `sinatra-base`'s. Both carry json, puma, rack,

--- a/docs/no-docker-daemon-abstraction.md
+++ b/docs/no-docker-daemon-abstraction.md
@@ -1,0 +1,48 @@
+# context.daemon is a transport, not a daemon
+
+`context.daemon` answers a `UnixSocketHttp`, so every caller writes its own
+docker URL:
+
+    daemon.request('GET', '/images/json')
+    daemon.request('POST', "/images/create?fromImage=#{image_name}")
+    daemon.request('GET', "/containers/#{id}/archive?path=#{RAG_LAMBDA_FILENAME}")
+
+The class is right about itself. Its comment says it speaks HTTP over a unix
+socket of any kind, and `context.rb` puts the socket path at the wiring for
+that reason. A transport taking a path per call is what `Net::HTTP` does too:
+the path it owns is the socket's, not the URL's.
+
+The name is what does not fit. `daemon` promises something that knows about
+docker and delivers something that knows about HTTP, which is why the URLs look
+like they are on the wrong side of the boundary. They are on the only side
+there is.
+
+## What is spread out
+
+Four files assemble docker URLs: `node.rb`, `puller.rb`, `traffic_light.rb`,
+`daemon_run.rb`. `DaemonRun` is already the abstraction this describes, for the
+run sequence alone; the other three have no equivalent and reach the transport
+directly.
+
+Two things this costs, both observed rather than imagined:
+
+- `docs/docker-socket-privilege.md` needs the complete list of endpoints the
+  runner uses, to say what a socket proxy would allow. That list had to be
+  reconstructed by grepping four files. An abstraction would be the list.
+- Three test doubles stand in for the daemon: `DaemonOneRequestStub`,
+  `DaemonSequenceStub`, `DaemonStub`. All three match on the URL, and the last
+  routes on `path.start_with?('/containers/create')` after an earlier version
+  routed on the substring `create` and would have answered an image pull as a
+  container create. Stubs match on URLs because the seam is at the transport.
+
+## The shape it would take
+
+A `DockerDaemon` holding a `UnixSocketHttp`, answering `image_names`,
+`pull_image(name)`, `create_container(config)`, `read_file(id, path)` and
+`remove_container(id)`. `context.daemon` would answer that, and the transport
+would become something only it holds.
+
+Against it: the whole daemon surface is eight endpoints in a service of this
+size, so the layer earns its keep only if something else wants that list, and
+`DaemonRun` would have to move inside it or go on holding its own client.
+Deciding that is not urgent, and nothing is broken while it stays as it is.

--- a/docs/runner-as-docker-group.txt
+++ b/docs/runner-as-docker-group.txt
@@ -1,3 +1,0 @@
-
-runner as docker-group user
-https://estl.tech/accessing-docker-from-a-kubernetes-pod-68996709c04b

--- a/source/client/http_proxy/net_http_adapter.rb
+++ b/source/client/http_proxy/net_http_adapter.rb
@@ -7,9 +7,9 @@ module HttpProxy
     end
 
     def post(uri)
-      # :nocov:
+      # simplecov:disable
       Net::HTTP::Post.new(uri)
-      # :nocov:
+      # simplecov:enable
     end
 
     def start(hostname, port, req)

--- a/test/dual/run_red_amber_green_test.rb
+++ b/test/dual/run_red_amber_green_test.rb
@@ -10,7 +10,7 @@ module Dual
       run_cyber_dojo_sh
       assert red?, run_result
       on_client do
-        # :nocov:
+        # simplecov:disable
         expected_stdout = ''
         expected_stderr = [
           'Assertion failed: answer() == 42 (hiker.tests.c: life_the_universe_and_everything: 7)',
@@ -24,7 +24,7 @@ module Dual
           assert stderr.include?(line), diagnostic
         end
         assert_equal expected_status, status, :status
-        # :nocov:
+        # simplecov:enable
       end
     end
 
@@ -35,7 +35,7 @@ module Dual
       run_cyber_dojo_sh_with_edit('hiker.c', '6 * 9', '6 * 9s')
       assert amber?, run_result
       on_client do
-        # :nocov:
+        # simplecov:disable
         expected_stdout = ''
         expected_stderr = [
           "hiker.c:5:16: error: invalid suffix 's' on integer constant",
@@ -49,7 +49,7 @@ module Dual
           assert stderr.include?(line), diagnostic
         end
         assert_equal expected_status, status, :status
-        # :nocov:
+        # simplecov:enable
       end
     end
 
@@ -60,14 +60,14 @@ module Dual
       run_cyber_dojo_sh_with_edit('hiker.c', '6 * 9', '6 * 7')
       assert green?, run_result
       on_client do
-        # :nocov:
+        # simplecov:disable
         assert_equal "All tests passed\n", stdout
         expected_stderr =
           "(INFO) Reading coverage data...\n" \
           "(INFO) Writing coverage report...\n"
         assert_equal expected_stderr, stderr
         assert_equal '0', status
-        # :nocov:
+        # simplecov:enable
       end
     end
 
@@ -75,12 +75,12 @@ module Dual
 
     def stub(colour)
       on_client do
-        # :nocov:
+        # simplecov:disable
         set_context
-        # :nocov:
+        # simplecov:enable
       end
       on_server do
-        # :nocov:
+        # simplecov:disable
         stdout_tgz = TGZ.of({ 'stderr' => 'any' })
         # The rag-lambda arrives as a tar, being what the daemon's archive
         # endpoint answers when TrafficLight reads it out of the image.
@@ -91,7 +91,7 @@ module Dual
           daemon: DaemonStub.new(stdout: stdout_tgz, archive: tar.tar_file)
         )
         puller.add(image_name)
-        # :nocov:
+        # simplecov:enable
       end
     end
 

--- a/test/lib/coverage.rb
+++ b/test/lib/coverage.rb
@@ -13,12 +13,12 @@ SimpleCov.start do
   code_tab = ENV.fetch('COVERAGE_CODE_TAB_NAME')
   test_tab = ENV.fetch('COVERAGE_TEST_TAB_NAME')
 
-  # add_group('debug') { |the| puts the.filename; false }
+  # group('debug') { |the| puts the.filename; false }
 
-  add_group(test_tab) do |the|
+  group(test_tab) do |the|
     the.filename.start_with?("#{APP_DIR}/test/#{CONTEXT}/") || the.filename.start_with?("#{APP_DIR}/test/dual/")
   end
-  add_group(code_tab) do |the|
+  group(code_tab) do |the|
     the.filename.start_with?("#{APP_DIR}/source/")
   end
 end


### PR DESCRIPTION
  Two things in the test harness were written for simplecov 0.21.2, which
  is what sinatra-base carried when the runner moved onto it. The base
  image now resolves 1.1.1, and both spellings are deprecated there,
  each announcing itself on stderr on every run:

    SimpleCov.add_group -> SimpleCov.group
    # :nocov:           -> # simplecov:disable / # simplecov:enable

  Coverage is unchanged: test.lines.total 1141, code.lines.total 674,
  nothing missed, which is what says the markers still exempt the same
  lines they did before.

  Both were flagged as temporary when they went in, but only add_group was
  expected to come back. `# :nocov:` was checked to still work on 1.x and
  recorded as needing no undoing; it does still work, and it is also
  deprecated, which that check did not ask about.